### PR TITLE
Ensure drag events set data for map elements

### DIFF
--- a/src/components/Seats/SeatsManagement.tsx
+++ b/src/components/Seats/SeatsManagement.tsx
@@ -161,12 +161,16 @@ const SeatsManagement: React.FC = () => {
     setDraggedBench(benchId);
     setDraggedPreset(null);
     e.dataTransfer.effectAllowed = 'move';
+    // Some browsers require data to be set for drag events to fire properly
+    e.dataTransfer.setData('text/plain', benchId);
   };
 
   const handlePresetDragStart = (e: React.DragEvent, preset: any) => {
     setDraggedPreset(preset);
     setDraggedBench(null);
     e.dataTransfer.effectAllowed = 'copy';
+    // Set dummy data to ensure drop event is triggered across browsers
+    e.dataTransfer.setData('text/plain', preset.id);
   };
 
   const handleBenchDragEnd = () => {


### PR DESCRIPTION
## Summary
- set data on drag start to enable dropping benches and preset elements on the map

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 'Award' is defined but never used, Unexpected any, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68a0fd52e438832386a957346229e944