### PR TITLE
chore: set project port to 5000

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,4 +7,10 @@ export default defineConfig({
   optimizeDeps: {
     exclude: ['lucide-react'],
   },
+  server: {
+    port: 5000,
+  },
+  preview: {
+    port: 5000,
+  },
 });


### PR DESCRIPTION
## Summary
- configure Vite server and preview to use port 5000

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: 11 errors, 1 warning)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a3a7c7e23c8323ab386b318cd39662