### PR TITLE
fix: handle function initial value in useLocalStorage

### DIFF
--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,13 +1,20 @@
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 
-export function useLocalStorage<T>(key: string, initialValue: T): [T, (value: T | ((val: T) => T)) => void] {
+// Allows lazy initialization by accepting a value or a function that returns a value
+export function useLocalStorage<T>(
+  key: string,
+  initialValue: T | (() => T)
+): [T, (value: T | ((val: T) => T)) => void] {
   const [storedValue, setStoredValue] = useState<T>(() => {
     try {
       const item = window.localStorage.getItem(key);
-      return item ? JSON.parse(item) : initialValue;
+      if (item) {
+        return JSON.parse(item);
+      }
+      return initialValue instanceof Function ? initialValue() : initialValue;
     } catch (error) {
       console.error(`Error loading ${key} from localStorage:`, error);
-      return initialValue;
+      return initialValue instanceof Function ? initialValue() : initialValue;
     }
   });
 


### PR DESCRIPTION
## Summary
- allow `useLocalStorage` to accept initializer functions for lazy setup
- fix crash when `seats` state from localStorage was a function instead of array

## Testing
- `npx eslint src/hooks/useLocalStorage.ts`
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 10 errors in existing files)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a47bf874608323bcad82215a6a57e6