### PR TITLE
Add arrows to expand map boundaries

### DIFF
--- a/src/components/Seats/MapBoundsControls.tsx
+++ b/src/components/Seats/MapBoundsControls.tsx
@@ -1,0 +1,58 @@
+import React from 'react';
+import { ChevronUp, ChevronRight, ChevronDown, ChevronLeft } from 'lucide-react';
+import { useAppContext } from '../../context/AppContext';
+
+const MapBoundsControls: React.FC = () => {
+  const { mapBounds, setMapBounds } = useAppContext();
+
+  const expand = (side: 'top' | 'right' | 'bottom' | 'left') => {
+    setMapBounds(prev => ({
+      ...prev,
+      [side]: Math.max(0, prev[side] - 20),
+    }));
+  };
+
+  return (
+    <div
+      className="absolute border-2 border-gray-400 pointer-events-none"
+      style={{
+        top: mapBounds.top,
+        left: mapBounds.left,
+        right: mapBounds.right,
+        bottom: mapBounds.bottom,
+      }}
+    >
+      <button
+        onClick={() => expand('top')}
+        className="absolute top-0 left-1/2 transform -translate-x-1/2 -translate-y-full bg-white rounded-full shadow p-1 pointer-events-auto"
+        aria-label="הרחב למעלה"
+      >
+        <ChevronUp className="h-4 w-4" />
+      </button>
+      <button
+        onClick={() => expand('right')}
+        className="absolute top-1/2 right-0 transform translate-x-full -translate-y-1/2 bg-white rounded-full shadow p-1 pointer-events-auto"
+        aria-label="הרחב ימינה"
+      >
+        <ChevronRight className="h-4 w-4" />
+      </button>
+      <button
+        onClick={() => expand('bottom')}
+        className="absolute bottom-0 left-1/2 transform -translate-x-1/2 translate-y-full bg-white rounded-full shadow p-1 pointer-events-auto"
+        aria-label="הרחב למטה"
+      >
+        <ChevronDown className="h-4 w-4" />
+      </button>
+      <button
+        onClick={() => expand('left')}
+        className="absolute top-1/2 left-0 transform -translate-x-full -translate-y-1/2 bg-white rounded-full shadow p-1 pointer-events-auto"
+        aria-label="הרחב שמאלה"
+      >
+        <ChevronLeft className="h-4 w-4" />
+      </button>
+    </div>
+  );
+};
+
+export default MapBoundsControls;
+

--- a/src/components/Seats/SeatsManagement.tsx
+++ b/src/components/Seats/SeatsManagement.tsx
@@ -18,6 +18,7 @@ import {
   ArrowDown,
   ArrowDownRight
 } from 'lucide-react';
+import MapBoundsControls from './MapBoundsControls';
 
 const specialElements = [
   {
@@ -677,15 +678,7 @@ const SeatsManagement: React.FC = () => {
             >
               {renderGrid()}
 
-              <div
-                className="absolute border-2 border-gray-400 pointer-events-none"
-                style={{
-                  top: mapBounds.top,
-                  left: mapBounds.left,
-                  right: mapBounds.right,
-                  bottom: mapBounds.bottom,
-                }}
-              />
+              <MapBoundsControls />
 
               {/* רינדור ספסלים */}
               {benches.map((bench) => (

--- a/src/components/Seats/SeatsView.tsx
+++ b/src/components/Seats/SeatsView.tsx
@@ -2,9 +2,10 @@ import React from 'react';
 import { useAppContext } from '../../context/AppContext';
 import { Seat, User } from '../../types';
 import { Users as UsersIcon, MapPin, User as UserIcon, Grid3X3, Armchair } from 'lucide-react';
+import MapBoundsControls from './MapBoundsControls';
 
 const SeatsView: React.FC = () => {
-  const { seats, users, benches, gridSettings, mapBounds } = useAppContext();
+  const { seats, users, benches, gridSettings } = useAppContext();
 
   const getUserById = (userId: string): User | undefined => {
     return users.find(user => user.id === userId);
@@ -156,15 +157,7 @@ const SeatsView: React.FC = () => {
         >
           {renderGrid()}
 
-          <div
-            className="absolute border-2 border-gray-400 pointer-events-none"
-            style={{
-              top: mapBounds.top,
-              left: mapBounds.left,
-              right: mapBounds.right,
-              bottom: mapBounds.bottom,
-            }}
-          />
+          <MapBoundsControls />
 
           {/* רינדור ספסלים */}
           {benches.map((bench) => (


### PR DESCRIPTION
## Summary
- add `MapBoundsControls` component with arrows to expand the map area
- integrate boundary controls into seat view and management pages

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a505ec0e0c8323ac7f3b7f5a78dd96