### PR TITLE
Ignore arrow keys when editing bench fields

### DIFF
--- a/src/components/Seats/SeatsManagement.tsx
+++ b/src/components/Seats/SeatsManagement.tsx
@@ -488,6 +488,9 @@ const SeatsManagement: React.FC = () => {
     const handleKeyDown = (e: KeyboardEvent) => {
       if (selectedBenchIds.length === 0) return;
 
+      const target = e.target as HTMLElement;
+      if (target && target.closest('input, textarea, select, [contenteditable="true"]')) return;
+
       const moveDistance = gridSettings.snapToGrid ? gridSettings.gridSize : 10;
 
       if (['ArrowUp', 'ArrowDown', 'ArrowLeft', 'ArrowRight'].includes(e.key)) {


### PR DESCRIPTION
## Summary
- Skip moving benches when arrow keys are used within input, textarea, or select elements

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a506f3631c8323b9c5902c4934bca4