### PR TITLE
Add zoom controls to seating map

### DIFF
--- a/src/components/Seats/MapZoomControls.tsx
+++ b/src/components/Seats/MapZoomControls.tsx
@@ -1,0 +1,33 @@
+import React from 'react';
+import { Plus, Minus } from 'lucide-react';
+
+interface MapZoomControlsProps {
+  setZoom: React.Dispatch<React.SetStateAction<number>>;
+}
+
+const MapZoomControls: React.FC<MapZoomControlsProps> = ({ setZoom }) => {
+  const zoomIn = () => setZoom(prev => Math.min(prev + 0.1, 2));
+  const zoomOut = () => setZoom(prev => Math.max(prev - 0.1, 0.5));
+
+  return (
+    <div className="absolute top-4 left-4 flex flex-col bg-white rounded shadow-md z-50">
+      <button
+        onClick={zoomIn}
+        className="p-2 hover:bg-gray-100 border-b"
+        aria-label="הגדל מפה"
+      >
+        <Plus className="h-4 w-4" />
+      </button>
+      <button
+        onClick={zoomOut}
+        className="p-2 hover:bg-gray-100"
+        aria-label="הקטן מפה"
+      >
+        <Minus className="h-4 w-4" />
+      </button>
+    </div>
+  );
+};
+
+export default MapZoomControls;
+

--- a/src/components/Seats/SeatsView.tsx
+++ b/src/components/Seats/SeatsView.tsx
@@ -1,11 +1,13 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { useAppContext } from '../../context/AppContext';
 import { Seat, User } from '../../types';
 import { Users as UsersIcon, MapPin, User as UserIcon, Grid3X3, Armchair } from 'lucide-react';
 import MapBoundsControls from './MapBoundsControls';
+import MapZoomControls from './MapZoomControls';
 
 const SeatsView: React.FC = () => {
   const { seats, users, benches, gridSettings } = useAppContext();
+  const [zoom, setZoom] = useState(1);
 
   const getUserById = (userId: string): User | undefined => {
     return users.find(user => user.id === userId);
@@ -147,20 +149,28 @@ const SeatsView: React.FC = () => {
           )}
         </div>
 
-        <div 
+        <div
           className="relative border-2 border-gray-200 rounded-lg overflow-hidden bg-gray-50"
-          style={{ 
+          style={{
             minHeight: '800px',
             width: '1200px',
             maxWidth: '100%',
           }}
         >
-          {renderGrid()}
+          <div
+            style={{
+              transform: `scale(${zoom})`,
+              transformOrigin: 'top left',
+              width: '1200px',
+              height: '800px',
+            }}
+          >
+            {renderGrid()}
 
-          <MapBoundsControls />
+            <MapBoundsControls />
 
-          {/* רינדור ספסלים */}
-          {benches.map((bench) => (
+            {/* רינדור ספסלים */}
+            {benches.map((bench) => (
             <div
               key={bench.id}
               className="absolute rounded-lg shadow-lg border-2 border-white"
@@ -225,7 +235,9 @@ const SeatsView: React.FC = () => {
                   );
                 })}
             </div>
-          ))}
+            ))}
+          </div>
+          <MapZoomControls setZoom={setZoom} />
         </div>
       </div>
 


### PR DESCRIPTION
## Summary
- add MapZoomControls component with plus/minus buttons
- integrate zoom state and scaling into SeatsView map

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a50a3097888323bbc0d9c2b28291fc