### PR TITLE
feat: add map clearing and panning

### DIFF
--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -1,5 +1,5 @@
 import React, { createContext, useContext, ReactNode } from 'react';
-import { User, Seat, Bench, GridSettings, MapBounds } from '../types';
+import { User, Seat, Bench, GridSettings, MapBounds, MapOffset } from '../types';
 import { useLocalStorage } from '../hooks/useLocalStorage';
 
 interface AppContextType {
@@ -13,6 +13,8 @@ interface AppContextType {
   setGridSettings: (settings: GridSettings | ((prev: GridSettings) => GridSettings)) => void;
   mapBounds: MapBounds;
   setMapBounds: (bounds: MapBounds | ((prev: MapBounds) => MapBounds)) => void;
+  mapOffset: MapOffset;
+  setMapOffset: (offset: MapOffset | ((prev: MapOffset) => MapOffset)) => void;
 }
 
 const AppContext = createContext<AppContextType | undefined>(undefined);
@@ -123,6 +125,11 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
     left: 20,
   });
 
+  const [mapOffset, setMapOffset] = useLocalStorage<MapOffset>('mapOffset', {
+    x: 0,
+    y: 0,
+  });
+
   return (
     <AppContext.Provider value={{ 
       users, 
@@ -134,7 +141,9 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
       gridSettings,
       setGridSettings,
       mapBounds,
-      setMapBounds
+      setMapBounds,
+      mapOffset,
+      setMapOffset
     }}>
       {children}
     </AppContext.Provider>

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -54,3 +54,8 @@ export interface MapBounds {
   bottom: number;
   left: number;
 }
+
+export interface MapOffset {
+  x: number;
+  y: number;
+}


### PR DESCRIPTION
## Summary
- allow panning the seating map with a hand tool and selection box for multi-move
- add map clearing option and persistent map offset
- wire map offset into context for reuse

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a50c7b50788323b91293f54648f5b4