### PR TITLE
Fix map bounds expansion

### DIFF
--- a/src/components/Seats/MapBoundsControls.tsx
+++ b/src/components/Seats/MapBoundsControls.tsx
@@ -8,7 +8,8 @@ const MapBoundsControls: React.FC = () => {
   const expand = (side: 'top' | 'right' | 'bottom' | 'left') => {
     setMapBounds(prev => ({
       ...prev,
-      [side]: Math.max(0, prev[side] - 20),
+      // allow negative values so the map can grow beyond its initial bounds
+      [side]: prev[side] - 20,
     }));
   };
 


### PR DESCRIPTION
## Summary
- allow negative values when expanding map bounds so arrows keep expanding

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a59368705c8323a8aa13f748beb121