### PR TITLE
Remove inner map border

### DIFF
--- a/src/components/Seats/MapBoundsControls.tsx
+++ b/src/components/Seats/MapBoundsControls.tsx
@@ -19,7 +19,7 @@ const MapBoundsControls: React.FC = () => {
 
   return (
     <div
-      className="absolute border-2 border-gray-400 pointer-events-none"
+      className="absolute pointer-events-none"
       style={{
         top: mapBounds.top,
         left: mapBounds.left,


### PR DESCRIPTION
## Summary
- remove inner border around map bounds controls to declutter map view

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5b7f6166c83238584ccf9f902595f