### PR TITLE
feat: mark map center

### DIFF
--- a/src/components/Seats/SeatsManagement.tsx
+++ b/src/components/Seats/SeatsManagement.tsx
@@ -862,15 +862,18 @@ const SeatsManagement: React.FC = () => {
               >
                 {renderGrid()}
 
+                {/* סימון מרכז המפה */}
+                <div className="absolute left-1/2 top-1/2 w-4 h-4 bg-red-500 rounded-full border-2 border-white transform -translate-x-1/2 -translate-y-1/2 pointer-events-none z-50" />
+
                 {/* רינדור ספסלים */}
                 {benches.map((bench) => (
-                <div
-                  key={bench.id}
-                  className={`absolute rounded-lg shadow-lg border-2 transition-all duration-200 hover:shadow-xl ${
-                    bench.locked ? 'cursor-not-allowed' : 'cursor-move'
-                  } ${selectedBenchIds.includes(bench.id) ? 'ring-4 ring-blue-300' : ''} ${
-                    draggedBench === bench.id ? 'opacity-50' : ''
-                  }`}
+                  <div
+                    key={bench.id}
+                    className={`absolute rounded-lg shadow-lg border-2 transition-all duration-200 hover:shadow-xl ${
+                      bench.locked ? 'cursor-not-allowed' : 'cursor-move'
+                    } ${selectedBenchIds.includes(bench.id) ? 'ring-4 ring-blue-300' : ''} ${
+                      draggedBench === bench.id ? 'opacity-50' : ''
+                    }`}
                   style={{
                     left: `${bench.position.x}px`,
                     top: `${bench.position.y}px`,

--- a/src/components/Seats/SeatsView.tsx
+++ b/src/components/Seats/SeatsView.tsx
@@ -123,6 +123,7 @@ const SeatsView: React.FC = () => {
           }}
         >
           <div
+            className="relative"
             style={{
               transform: `scale(${zoom})`,
               transformOrigin: 'top left',
@@ -131,6 +132,9 @@ const SeatsView: React.FC = () => {
             }}
           >
             {renderGrid()}
+
+            {/* סימון מרכז המפה */}
+            <div className="absolute left-1/2 top-1/2 w-4 h-4 bg-red-500 rounded-full border-2 border-white transform -translate-x-1/2 -translate-y-1/2 pointer-events-none z-50" />
 
             {/* רינדור ספסלים */}
               {benches.map((bench) => (


### PR DESCRIPTION
## Summary
- highlight map center for seat view and management

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a5bdceb494832394aead60f7e382eb