### PR TITLE
Elevate bench settings button z-index

### DIFF
--- a/src/components/Seats/SeatsManagement.tsx
+++ b/src/components/Seats/SeatsManagement.tsx
@@ -894,13 +894,13 @@ const SeatsManagement: React.FC = () => {
                       e.stopPropagation();
                       setOpenSettingsId(openSettingsId === bench.id ? null : bench.id);
                     }}
-                    className="absolute top-1 left-1 z-10 p-1 bg-white rounded shadow-md hover:bg-gray-50 transition-colors"
+                    className="absolute top-1 left-1 z-[50] p-1 bg-white rounded shadow-md hover:bg-gray-50 transition-colors"
                     title="הגדרות"
                   >
                     <Settings className="h-3 w-3 text-gray-600" />
                   </button>
                   {openSettingsId === bench.id && (
-                    <div className="absolute top-1 left-7 z-20 flex space-x-1 space-x-reverse p-1 bg-white rounded shadow-md">
+                    <div className="absolute top-1 left-7 z-[60] flex space-x-1 space-x-reverse p-1 bg-white rounded shadow-md">
                       <button
                         onClick={(e) => {
                           e.stopPropagation();


### PR DESCRIPTION
## Summary
- Ensure bench settings button overlays other elements
- Raise settings dropdown z-index for clear visibility

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5c12d4a8c8323af958428aedb0482