### PR TITLE
Render special elements with consistent size in map view

### DIFF
--- a/src/components/Seats/SeatsView.tsx
+++ b/src/components/Seats/SeatsView.tsx
@@ -153,8 +153,16 @@ const SeatsView: React.FC = () => {
                   <div
                     className="rounded-lg shadow-lg border-2 border-white"
                     style={{
-                      width: bench.orientation === 'horizontal' ? `${bench.seatCount * 60 + 20}px` : '80px',
-                      height: bench.orientation === 'horizontal' ? '80px' : `${bench.seatCount * 60 + 20}px`,
+                      width: bench.type === 'special'
+                        ? `${bench.width}px`
+                        : bench.orientation === 'horizontal'
+                          ? `${bench.seatCount * 60 + 20}px`
+                          : '80px',
+                      height: bench.type === 'special'
+                        ? `${bench.height}px`
+                        : bench.orientation === 'horizontal'
+                          ? '80px'
+                          : `${bench.seatCount * 60 + 20}px`,
                       backgroundColor: `${bench.color}20`,
                       borderColor: bench.color,
                     }}


### PR DESCRIPTION
## Summary
- Use stored width and height for special elements in map display

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a5c1b9b49c8323a600cd108e5de7ef