### PR TITLE
feat: support multiple map configurations

### DIFF
--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -65,3 +65,21 @@ export interface MapOffset {
   x: number;
   y: number;
 }
+
+export interface MapData {
+  id: string;
+  name: string;
+  benches: Bench[];
+  seats: Seat[];
+  mapBounds: MapBounds;
+  mapOffset: MapOffset;
+}
+
+export interface MapTemplate {
+  id: string;
+  name: string;
+  benches: Bench[];
+  seats: Seat[];
+  mapBounds: MapBounds;
+  mapOffset: MapOffset;
+}


### PR DESCRIPTION
## Summary
- add MapData and MapTemplate types for describing map layouts
- extend context with persistence for multiple maps and templates
- expose utilities to save, load, delete and template-based creation of maps

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a61f097450832392c7e5596ee5c9a6