### PR TITLE
fix: ensure Hebrew CSV is UTF-8

### DIFF
--- a/src/components/Worshipers/WorshiperManagement.tsx
+++ b/src/components/Worshipers/WorshiperManagement.tsx
@@ -29,12 +29,13 @@ const WorshiperManagement: React.FC = () => {
     reader.onload = () => {
       const text = reader.result as string;
       const rows = text.trim().split(/\r?\n/);
-      const headers = rows.shift()?.split(',') ?? [];
+      const headers =
+        rows.shift()?.split(',').map(h => h.trim().replace(/^\ufeff/, '')) ?? [];
       const imported = rows.map((row, index) => {
         const values = row.split(',');
         const obj: Record<string, string> = {};
         headers.forEach((h, i) => {
-          obj[h.trim()] = values[i]?.trim() || '';
+          obj[h] = values[i]?.trim() || '';
         });
         return {
           id: Date.now().toString() + index,
@@ -51,14 +52,14 @@ const WorshiperManagement: React.FC = () => {
       });
       setWorshipers(prev => [...prev, ...imported]);
     };
-    reader.readAsText(file);
+    reader.readAsText(file, 'UTF-8');
     e.target.value = '';
   };
 
   const downloadSampleCsv = () => {
     const headers = ['תואר', 'שם פרטי', 'שם משפחה', 'כתובת', 'עיר', 'טלפון', 'טלפון נוסף', 'אימייל', 'כמות מקומות'];
     const sample = ['מר', 'דוד', 'כהן', 'רחוב הדוגמה 1', 'תל אביב', '050-0000000', '', 'david@example.com', '1'];
-    const csvContent = [headers.join(','), sample.join(',')].join('\n');
+    const csvContent = '\ufeff' + [headers.join(','), sample.join(',')].join('\n');
     const blob = new Blob([csvContent], { type: 'text/csv;charset=utf-8;' });
     const url = URL.createObjectURL(blob);
     const link = document.createElement('a');


### PR DESCRIPTION
## Summary
- handle BOM and UTF-8 when uploading worshiper CSV files
- add UTF-8 BOM to sample CSV download for Hebrew compatibility

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68a61f8e983c832392800f33041f351b