### PR TITLE
feat: add default map listing and save button

### DIFF
--- a/src/components/Seats/SeatsManagement.tsx
+++ b/src/components/Seats/SeatsManagement.tsx
@@ -161,7 +161,7 @@ const ensureBenchSpacing = (
 };
 
 const SeatsManagement: React.FC = () => {
-  const { seats, setSeats, worshipers, benches, setBenches, gridSettings, setGridSettings, mapBounds, setMapBounds, mapOffset, setMapOffset, maps } = useAppContext();
+  const { seats, setSeats, worshipers, benches, setBenches, gridSettings, setGridSettings, mapBounds, setMapBounds, mapOffset, setMapOffset, maps, saveCurrentMap } = useAppContext();
   const updateBenches = useCallback(
     (updater: Bench[] | ((prev: Bench[]) => Bench[])) => {
       if (typeof updater === 'function') {
@@ -212,6 +212,13 @@ const SeatsManagement: React.FC = () => {
   const [isSelecting, setIsSelecting] = useState(false);
   const [selectionStart, setSelectionStart] = useState<{ x: number; y: number } | null>(null);
   const [selectionRect, setSelectionRect] = useState<{ x: number; y: number; width: number; height: number } | null>(null);
+
+  const handleSaveMap = () => {
+    const name = prompt('הכנס שם למפה החדשה:');
+    if (name) {
+      saveCurrentMap(name);
+    }
+  };
 
   const handleBoundChange = (side: keyof MapBounds, value: number) => {
     setMapBounds(prev => ({ ...prev, [side]: value }));
@@ -1545,6 +1552,13 @@ const SeatsManagement: React.FC = () => {
           {/* רשימת מפות בזכרון */}
           <div className="bg-white p-6 rounded-lg shadow-md">
             <h3 className="text-lg font-semibold text-gray-900 mb-4">מפות בזכרון</h3>
+            <button
+              onClick={handleSaveMap}
+              className="w-full flex items-center justify-center px-4 py-2 mb-4 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+            >
+              <Plus className="h-4 w-4 ml-2" />
+              הוסף מפה חדשה
+            </button>
             {maps.length === 0 ? (
               <p className="text-gray-600">אין מפות בזכרון</p>
             ) : (

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -247,39 +247,39 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
   ]);
   const initialBenches = generateInitialBenches();
   const initialSeats = generateSeatsFromBenches(initialBenches);
+  const defaultMap: MapData = {
+    id: 'default-map',
+    name: 'מפת ברירת מחדל',
+    benches: initialBenches,
+    seats: initialSeats,
+    mapBounds: { top: 20, right: 20, bottom: 20, left: 20 },
+    mapOffset: { x: 0, y: 0 },
+  };
   const [benches, setBenches] = useLocalStorage<Bench[]>('benches', initialBenches);
   const [seats, setSeats] = useLocalStorage<Seat[]>('seats', initialSeats);
 
-  const [maps, setMaps] = useLocalStorage<MapData[]>('maps', []);
-  const [currentMapId, setCurrentMapId] = useLocalStorage<string>('currentMapId', '');
+  const [maps, setMaps] = useLocalStorage<MapData[]>('maps', [defaultMap]);
+  const [currentMapId, setCurrentMapId] = useLocalStorage<string>('currentMapId', defaultMap.id);
 
   const defaultTemplate: MapTemplate = {
     id: 'default',
     name: 'תבנית ברירת מחדל',
     benches: initialBenches.map(b => ({ ...b })),
     seats: initialSeats.map(s => ({ ...s })),
-    mapBounds: { top: 20, right: 20, bottom: 20, left: 20 },
-    mapOffset: { x: 0, y: 0 },
+    mapBounds: defaultMap.mapBounds,
+    mapOffset: defaultMap.mapOffset,
   };
   const [mapTemplates, setMapTemplates] = useLocalStorage<MapTemplate[]>('mapTemplates', [defaultTemplate]);
-  
+
   const [gridSettings, setGridSettings] = useLocalStorage<GridSettings>('gridSettings', {
     showGrid: true,
     snapToGrid: true,
     gridSize: 20,
   });
 
-  const [mapBounds, setMapBounds] = useLocalStorage<MapBounds>('mapBounds', {
-    top: 20,
-    right: 20,
-    bottom: 20,
-    left: 20,
-  });
+  const [mapBounds, setMapBounds] = useLocalStorage<MapBounds>('mapBounds', defaultMap.mapBounds);
 
-  const [mapOffset, setMapOffset] = useLocalStorage<MapOffset>('mapOffset', {
-    x: 0,
-    y: 0,
-  });
+  const [mapOffset, setMapOffset] = useLocalStorage<MapOffset>('mapOffset', defaultMap.mapOffset);
 
   const saveCurrentMap = (name: string) => {
     const id = Date.now().toString();


### PR DESCRIPTION
## Summary
- include default map in stored maps and set it as initial selection
- allow saving current layout as a new map via button in seats management

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a62630e4048323a8a63cf747ee5c6c