### PR TITLE
Enable loading saved seat maps

### DIFF
--- a/src/components/Seats/SeatsManagement.tsx
+++ b/src/components/Seats/SeatsManagement.tsx
@@ -161,7 +161,23 @@ const ensureBenchSpacing = (
 };
 
 const SeatsManagement: React.FC = () => {
-  const { seats, setSeats, worshipers, benches, setBenches, gridSettings, setGridSettings, mapBounds, setMapBounds, mapOffset, setMapOffset, maps, saveCurrentMap } = useAppContext();
+  const {
+    seats,
+    setSeats,
+    worshipers,
+    benches,
+    setBenches,
+    gridSettings,
+    setGridSettings,
+    mapBounds,
+    setMapBounds,
+    mapOffset,
+    setMapOffset,
+    maps,
+    saveCurrentMap,
+    loadMap,
+    currentMapId,
+  } = useAppContext();
   const updateBenches = useCallback(
     (updater: Bench[] | ((prev: Bench[]) => Bench[])) => {
       if (typeof updater === 'function') {
@@ -1564,7 +1580,14 @@ const SeatsManagement: React.FC = () => {
             ) : (
               <ul className="space-y-2">
                 {maps.map(m => (
-                  <li key={m.id} className="p-2 bg-gray-100 rounded">{m.name}</li>
+                  <li key={m.id}>
+                    <button
+                      onClick={() => loadMap(m.id)}
+                      className={`w-full text-right p-2 rounded ${m.id === currentMapId ? 'bg-blue-100 text-blue-700' : 'bg-gray-100 hover:bg-gray-200'}`}
+                    >
+                      {m.name}
+                    </button>
+                  </li>
                 ))}
               </ul>
             )}


### PR DESCRIPTION
## Summary
- allow SeatsManagement to load selected maps from context
- make saved map list clickable and highlight active map

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a627bdc5b88323be0e0786190854b0