### PR TITLE
feat: add basic user authentication

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,19 +1,32 @@
 import React from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import { AppProvider } from './context/AppContext';
+import { AuthProvider } from './context/AuthContext';
 import Layout from './components/Layout/Layout';
 import WorshiperManagement from './components/Worshipers/WorshiperManagement';
 import SeatsView from './components/Seats/SeatsView';
 import SeatsManagement from './components/Seats/SeatsManagement';
 import Contact from './components/Contact/Contact';
 import About from './components/About/About';
+import Login from './components/Auth/Login';
+import RequireAuth from './components/Auth/RequireAuth';
 
 function App() {
   return (
-    <AppProvider>
+    <AuthProvider>
       <Router>
         <Routes>
-          <Route path="/" element={<Layout />}>
+          <Route path="/login" element={<Login />} />
+          <Route
+            path="/"
+            element={
+              <RequireAuth>
+                <AppProvider>
+                  <Layout />
+                </AppProvider>
+              </RequireAuth>
+            }
+          >
             <Route index element={<WorshiperManagement />} />
             <Route path="seats-view" element={<SeatsView />} />
             <Route path="seats-manage" element={<SeatsManagement />} />
@@ -22,7 +35,7 @@ function App() {
           </Route>
         </Routes>
       </Router>
-    </AppProvider>
+    </AuthProvider>
   );
 }
 

--- a/src/components/Auth/Login.tsx
+++ b/src/components/Auth/Login.tsx
@@ -1,0 +1,62 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../../context/AuthContext';
+
+const Login: React.FC = () => {
+  const [username, setUsername] = useState('');
+  const [password, setPassword] = useState('');
+  const [isRegister, setIsRegister] = useState(false);
+  const [error, setError] = useState('');
+  const navigate = useNavigate();
+  const { login, register } = useAuth();
+
+  const handleSubmit = (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      if (isRegister) {
+        register(username, password);
+      }
+      login(username, password);
+      navigate('/');
+    } catch (err) {
+      setError((err as Error).message);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50" dir="rtl">
+      <form onSubmit={handleSubmit} className="bg-white p-8 rounded shadow-md w-full max-w-sm space-y-4">
+        <h2 className="text-xl font-bold text-center">{isRegister ? 'הרשמה' : 'כניסה'}</h2>
+        {error && <div className="text-red-500 text-sm text-center">{error}</div>}
+        <input
+          type="text"
+          placeholder="שם משתמש"
+          value={username}
+          onChange={(e) => setUsername(e.target.value)}
+          className="w-full p-2 border rounded"
+          required
+        />
+        <input
+          type="password"
+          placeholder="סיסמה"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          className="w-full p-2 border rounded"
+          required
+        />
+        <button type="submit" className="w-full bg-blue-600 text-white py-2 rounded">
+          {isRegister ? 'הרשם והתחבר' : 'התחבר'}
+        </button>
+        <button
+          type="button"
+          onClick={() => setIsRegister(!isRegister)}
+          className="text-sm text-blue-600 underline w-full text-center"
+        >
+          {isRegister ? 'כבר רשום? התחבר' : 'משתמש חדש? הרשמה'}
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default Login;

--- a/src/components/Auth/RequireAuth.tsx
+++ b/src/components/Auth/RequireAuth.tsx
@@ -1,0 +1,16 @@
+import React from 'react';
+import { Navigate, useLocation } from 'react-router-dom';
+import { useAuth } from '../../context/AuthContext';
+
+const RequireAuth: React.FC<{ children: JSX.Element }> = ({ children }) => {
+  const { user } = useAuth();
+  const location = useLocation();
+
+  if (!user) {
+    return <Navigate to="/login" state={{ from: location }} replace />;
+  }
+
+  return children;
+};
+
+export default RequireAuth;

--- a/src/components/Layout/Navbar.tsx
+++ b/src/components/Layout/Navbar.tsx
@@ -1,16 +1,19 @@
 import React from 'react';
-import { Link, useLocation } from 'react-router-dom';
-import { 
-  Users, 
-  MapPin, 
-  Settings, 
-  Mail, 
+import { Link, useLocation, useNavigate } from 'react-router-dom';
+import {
+  Users,
+  MapPin,
+  Settings,
+  Mail,
   Info,
   Armchair
 } from 'lucide-react';
+import { useAuth } from '../../context/AuthContext';
 
 const Navbar: React.FC = () => {
   const location = useLocation();
+  const navigate = useNavigate();
+  const { logout } = useAuth();
 
   const navItems = [
     { path: '/', label: 'ניהול מתפללים', icon: Users },
@@ -29,7 +32,7 @@ const Navbar: React.FC = () => {
             <h1 className="text-xl font-bold text-gray-800">מערכת ניהול מקומות ישיבה</h1>
           </div>
           
-          <div className="flex space-x-1 space-x-reverse">
+          <div className="flex space-x-1 space-x-reverse items-center">
             {navItems.map((item) => {
               const Icon = item.icon;
               const isActive = location.pathname === item.path;
@@ -49,6 +52,15 @@ const Navbar: React.FC = () => {
                 </Link>
               );
             })}
+            <button
+              onClick={() => {
+                logout();
+                navigate('/login');
+              }}
+              className="flex items-center px-4 py-2 rounded-lg text-sm font-medium text-gray-600 hover:text-gray-900 hover:bg-gray-100"
+            >
+              יציאה
+            </button>
           </div>
         </div>
       </div>

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -10,6 +10,7 @@ import {
   MapTemplate,
 } from '../types';
 import { useLocalStorage } from '../hooks/useLocalStorage';
+import { useAuth } from './AuthContext';
 
 interface AppContextType {
   worshipers: Worshiper[];
@@ -188,6 +189,8 @@ const generateSeatsFromBenches = (benches: Bench[]): Seat[] => {
 };
 
 export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const { user } = useAuth();
+  const userKey = user?.username ?? 'guest';
   const [worshipers, setWorshipers] = useLocalStorage<Worshiper[]>('worshipers', [
     {
       id: '1',
@@ -244,7 +247,7 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
       email: 'avi@example.com',
       seatCount: 1,
     },
-  ]);
+  ], userKey);
   const initialBenches = generateInitialBenches();
   const initialSeats = generateSeatsFromBenches(initialBenches);
   const defaultMap: MapData = {
@@ -255,11 +258,11 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
     mapBounds: { top: 20, right: 20, bottom: 20, left: 20 },
     mapOffset: { x: 0, y: 0 },
   };
-  const [benches, setBenches] = useLocalStorage<Bench[]>('benches', initialBenches);
-  const [seats, setSeats] = useLocalStorage<Seat[]>('seats', initialSeats);
+  const [benches, setBenches] = useLocalStorage<Bench[]>('benches', initialBenches, userKey);
+  const [seats, setSeats] = useLocalStorage<Seat[]>('seats', initialSeats, userKey);
 
-  const [maps, setMaps] = useLocalStorage<MapData[]>('maps', [defaultMap]);
-  const [currentMapId, setCurrentMapId] = useLocalStorage<string>('currentMapId', defaultMap.id);
+  const [maps, setMaps] = useLocalStorage<MapData[]>('maps', [defaultMap], userKey);
+  const [currentMapId, setCurrentMapId] = useLocalStorage<string>('currentMapId', defaultMap.id, userKey);
 
   const defaultTemplate: MapTemplate = {
     id: 'default',
@@ -269,17 +272,17 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
     mapBounds: defaultMap.mapBounds,
     mapOffset: defaultMap.mapOffset,
   };
-  const [mapTemplates, setMapTemplates] = useLocalStorage<MapTemplate[]>('mapTemplates', [defaultTemplate]);
+  const [mapTemplates, setMapTemplates] = useLocalStorage<MapTemplate[]>('mapTemplates', [defaultTemplate], userKey);
 
   const [gridSettings, setGridSettings] = useLocalStorage<GridSettings>('gridSettings', {
     showGrid: true,
     snapToGrid: true,
     gridSize: 20,
-  });
+  }, userKey);
 
-  const [mapBounds, setMapBounds] = useLocalStorage<MapBounds>('mapBounds', defaultMap.mapBounds);
+  const [mapBounds, setMapBounds] = useLocalStorage<MapBounds>('mapBounds', defaultMap.mapBounds, userKey);
 
-  const [mapOffset, setMapOffset] = useLocalStorage<MapOffset>('mapOffset', defaultMap.mapOffset);
+  const [mapOffset, setMapOffset] = useLocalStorage<MapOffset>('mapOffset', defaultMap.mapOffset, userKey);
 
   const saveCurrentMap = (name: string) => {
     const id = Date.now().toString();

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -1,0 +1,53 @@
+import React, { createContext, useContext, ReactNode } from 'react';
+import { useLocalStorage } from '../hooks/useLocalStorage';
+
+interface User {
+  username: string;
+  password: string;
+}
+
+interface AuthContextType {
+  user: User | null;
+  login: (username: string, password: string) => void;
+  register: (username: string, password: string) => void;
+  logout: () => void;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+export const useAuth = () => {
+  const context = useContext(AuthContext);
+  if (!context) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+};
+
+export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
+  const [users, setUsers] = useLocalStorage<User[]>('users', []);
+  const [user, setUser] = useLocalStorage<User | null>('currentUser', null);
+
+  const login = (username: string, password: string) => {
+    const existing = users.find(u => u.username === username && u.password === password);
+    if (!existing) {
+      throw new Error('שם משתמש או סיסמה שגויים');
+    }
+    setUser(existing);
+  };
+
+  const register = (username: string, password: string) => {
+    if (users.find(u => u.username === username)) {
+      throw new Error('שם משתמש כבר קיים');
+    }
+    const newUser = { username, password };
+    setUsers([...users, newUser]);
+  };
+
+  const logout = () => setUser(null);
+
+  return (
+    <AuthContext.Provider value={{ user, login, register, logout }}>
+      {children}
+    </AuthContext.Provider>
+  );
+};

--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,30 +1,45 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
 // Allows lazy initialization by accepting a value or a function that returns a value
 export function useLocalStorage<T>(
   key: string,
-  initialValue: T | (() => T)
+  initialValue: T | (() => T),
+  userId?: string
 ): [T, (value: T | ((val: T) => T)) => void] {
+  const storageKey = userId ? `${userId}-${key}` : key;
   const [storedValue, setStoredValue] = useState<T>(() => {
     try {
-      const item = window.localStorage.getItem(key);
+      const item = window.localStorage.getItem(storageKey);
       if (item) {
         return JSON.parse(item);
       }
       return initialValue instanceof Function ? initialValue() : initialValue;
     } catch (error) {
-      console.error(`Error loading ${key} from localStorage:`, error);
+      console.error(`Error loading ${storageKey} from localStorage:`, error);
       return initialValue instanceof Function ? initialValue() : initialValue;
     }
   });
+
+  useEffect(() => {
+    try {
+      const item = window.localStorage.getItem(storageKey);
+      if (item) {
+        setStoredValue(JSON.parse(item));
+      } else {
+        setStoredValue(initialValue instanceof Function ? initialValue() : initialValue);
+      }
+    } catch (error) {
+      console.error(`Error loading ${storageKey} from localStorage:`, error);
+    }
+  }, [storageKey, initialValue]);
 
   const setValue = (value: T | ((val: T) => T)) => {
     try {
       const valueToStore = value instanceof Function ? value(storedValue) : value;
       setStoredValue(valueToStore);
-      window.localStorage.setItem(key, JSON.stringify(valueToStore));
+      window.localStorage.setItem(storageKey, JSON.stringify(valueToStore));
     } catch (error) {
-      console.error(`Error saving ${key} to localStorage:`, error);
+      console.error(`Error saving ${storageKey} to localStorage:`, error);
     }
   };
 


### PR DESCRIPTION
## Summary
- add user context with login, register, and logout
- protect app routes behind authentication and add login page
- store map and worshiper data per user in local storage
- add logout option to navigation bar

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a629346e7883238f3af877ca9c4a0d