### PR TITLE
Use hash-based routing for smoother navigation

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import { HashRouter as Router, Routes, Route } from 'react-router-dom';
 import { AppProvider } from './context/AppContext';
 import { AuthProvider } from './context/AuthContext';
 import Layout from './components/Layout/Layout';


### PR DESCRIPTION
## Summary
- use `HashRouter` to ensure client-side pages load reliably via hash-based URLs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6464029c083238f2d16544aef07d9