### PR TITLE
Refactor navigation buttons to use client-side routing

### DIFF
--- a/src/components/Layout/Navbar.tsx
+++ b/src/components/Layout/Navbar.tsx
@@ -1,5 +1,5 @@
 import React from 'react';
-import { NavLink, useNavigate } from 'react-router-dom';
+import { useNavigate, useLocation } from 'react-router-dom';
 import {
   Users,
   MapPin,
@@ -12,6 +12,7 @@ import { useAuth } from '../../context/AuthContext';
 
 const Navbar: React.FC = () => {
   const navigate = useNavigate();
+  const location = useLocation();
   const { logout } = useAuth();
 
   const navItems = [
@@ -34,21 +35,20 @@ const Navbar: React.FC = () => {
           <div className="flex space-x-1 space-x-reverse items-center">
             {navItems.map((item) => {
               const Icon = item.icon;
+              const isActive = location.pathname === item.path;
               return (
-                <NavLink
+                <button
                   key={item.path}
-                  to={item.path}
-                  className={({ isActive }) =>
-                    `flex items-center px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-200 ${
-                      isActive
-                        ? 'bg-blue-100 text-blue-700 border border-blue-200'
-                        : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
-                    }`
-                  }
+                  onClick={() => navigate(item.path)}
+                  className={`flex items-center px-4 py-2 rounded-lg text-sm font-medium transition-colors duration-200 ${
+                    isActive
+                      ? 'bg-blue-100 text-blue-700 border border-blue-200'
+                      : 'text-gray-600 hover:text-gray-900 hover:bg-gray-100'
+                  }`}
                 >
                   <Icon className="h-4 w-4 ml-2" />
                   {item.label}
-                </NavLink>
+                </button>
               );
             })}
             <button


### PR DESCRIPTION
## Summary
- Ensure navigation buttons use `navigate` for smooth, automatic route changes
- Track active path with `useLocation` for proper styling

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a6481857fc8323be2401fc44d584ab