### PR TITLE
Update map saving to apply changes

### DIFF
--- a/src/components/Seats/SeatsManagement.tsx
+++ b/src/components/Seats/SeatsManagement.tsx
@@ -231,9 +231,13 @@ const SeatsManagement: React.FC = () => {
   const [selectionRect, setSelectionRect] = useState<{ x: number; y: number; width: number; height: number } | null>(null);
 
   const handleSaveMap = () => {
-    const name = prompt('הכנס שם למפה החדשה:');
-    if (name) {
-      saveCurrentMap(name);
+    if (currentMapId) {
+      saveCurrentMap();
+    } else {
+      const name = prompt('הכנס שם למפה החדשה:');
+      if (name) {
+        saveCurrentMap(name);
+      }
     }
   };
 
@@ -956,7 +960,7 @@ const SeatsManagement: React.FC = () => {
                   <button
                     onClick={handleSaveMap}
                     className="p-2 rounded-lg bg-green-100 text-green-600 hover:bg-green-200 transition-colors"
-                    title="שמור מפה"
+                    title="שמור שינויים"
                   >
                     <Save className="h-4 w-4" />
                   </button>

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -31,7 +31,7 @@ interface AppContextType {
   setCurrentMapId: (id: string) => void;
   mapTemplates: MapTemplate[];
   addTemplate: (template: MapTemplate) => void;
-  saveCurrentMap: (name: string) => void;
+  saveCurrentMap: (name?: string) => void;
   loadMap: (id: string) => void;
   deleteMap: (id: string) => void;
   createMapFromTemplate: (templateId: string, name: string) => void;
@@ -284,18 +284,28 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
 
   const [mapOffset, setMapOffset] = useLocalStorage<MapOffset>('mapOffset', defaultMap.mapOffset, userKey);
 
-  const saveCurrentMap = (name: string) => {
-    const id = Date.now().toString();
-    const map: MapData = {
-      id,
-      name,
-      benches,
-      seats,
-      mapBounds,
-      mapOffset,
-    };
-    setMaps(prev => [...prev, map]);
-    setCurrentMapId(id);
+  const saveCurrentMap = (name?: string) => {
+    if (currentMapId) {
+      setMaps(prev =>
+        prev.map(m =>
+          m.id === currentMapId
+            ? { ...m, benches, seats, mapBounds, mapOffset }
+            : m
+        )
+      );
+    } else if (name) {
+      const id = Date.now().toString();
+      const map: MapData = {
+        id,
+        name,
+        benches,
+        seats,
+        mapBounds,
+        mapOffset,
+      };
+      setMaps(prev => [...prev, map]);
+      setCurrentMapId(id);
+    }
   };
 
   const loadMap = (id: string) => {


### PR DESCRIPTION
## Summary
- Update context to save changes to current map instead of always creating new maps
- Use existing map when saving and prompt for name only for new maps
- Rename save button tooltip to "שמור שינויים" (Save changes)

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a64843c98c8323b708aec1e2dac1fb