### PR TITLE
Display worshiper names instead of seat numbers

### DIFF
--- a/src/components/Seats/SeatsManagement.tsx
+++ b/src/components/Seats/SeatsManagement.tsx
@@ -1175,9 +1175,11 @@ const SeatsManagement: React.FC = () => {
                             setSelectedSeat(seat.id);
                             setSelectedBenchIds([]);
                           }}
-                          title={status.worshiper ? `${status.worshiper.title} ${status.worshiper.firstName} ${status.worshiper.lastName}` : `מקום ${seat.id} - פנוי`}
+                          title={status.worshiper ? `${status.worshiper.title} ${status.worshiper.firstName} ${status.worshiper.lastName}` : 'פנוי'}
                         >
-                          <div className="text-white font-bold text-xs">{seat.id}</div>
+                          <div className="text-white font-bold text-[7px] leading-tight text-center px-1">
+                            {status.worshiper ? `${status.worshiper.title} ${status.worshiper.firstName} ${status.worshiper.lastName}` : 'פנוי'}
+                          </div>
                           
                           {status.worshiper && (
                             <div className="absolute -top-1 -right-1 w-4 h-4 bg-green-500 rounded-full flex items-center justify-center shadow-md">

--- a/src/components/Seats/SeatsView.tsx
+++ b/src/components/Seats/SeatsView.tsx
@@ -182,9 +182,11 @@ const SeatsView: React.FC = () => {
                               top: bench.orientation === 'horizontal' ? '10px' : `${index * 60 + 10}px`,
                               zIndex: 10,
                             }}
-                            title={status.worshiper ? `${status.worshiper.title} ${status.worshiper.firstName} ${status.worshiper.lastName}` : `מקום ${seat.id} - פנוי`}
+                            title={status.worshiper ? `${status.worshiper.title} ${status.worshiper.firstName} ${status.worshiper.lastName}` : 'פנוי'}
                           >
-                            <div className="text-white font-bold text-xs">{seat.id}</div>
+                            <div className="text-white font-bold text-[7px] leading-tight text-center px-1">
+                              {status.worshiper ? `${status.worshiper.title} ${status.worshiper.firstName} ${status.worshiper.lastName}` : 'פנוי'}
+                            </div>
 
                             {status.worshiper && (
                               <div className="absolute -top-1 -right-1 w-4 h-4 bg-green-500 rounded-full flex items-center justify-center shadow-md">
@@ -202,7 +204,7 @@ const SeatsView: React.FC = () => {
                                 </>
                               ) : (
                                 <>
-                                  <div>מקום {seat.id} - פנוי</div>
+                                  <div>פנוי</div>
                                   <div className="text-gray-400">{bench.name}</div>
                                 </>
                               )}


### PR DESCRIPTION
## Summary
- show worshiper's full name (with title) inside seat squares
- display 'פנוי' text for unassigned seats
- update management view to use names instead of seat numbers

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68a648ad30248323a9939e9e25235ce7