### PR TITLE
Fix re-render loop in useLocalStorage hook

### DIFF
--- a/src/hooks/useLocalStorage.ts
+++ b/src/hooks/useLocalStorage.ts
@@ -1,4 +1,4 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useRef } from 'react';
 
 // Allows lazy initialization by accepting a value or a function that returns a value
 export function useLocalStorage<T>(
@@ -7,16 +7,24 @@ export function useLocalStorage<T>(
   userId?: string
 ): [T, (value: T | ((val: T) => T)) => void] {
   const storageKey = userId ? `${userId}-${key}` : key;
+  const initialRef = useRef(initialValue);
+
   const [storedValue, setStoredValue] = useState<T>(() => {
     try {
       const item = window.localStorage.getItem(storageKey);
       if (item) {
         return JSON.parse(item);
       }
-      return initialValue instanceof Function ? initialValue() : initialValue;
+      const value =
+        initialRef.current instanceof Function
+          ? initialRef.current()
+          : initialRef.current;
+      return value;
     } catch (error) {
       console.error(`Error loading ${storageKey} from localStorage:`, error);
-      return initialValue instanceof Function ? initialValue() : initialValue;
+      return initialRef.current instanceof Function
+        ? initialRef.current()
+        : initialRef.current;
     }
   });
 
@@ -26,12 +34,16 @@ export function useLocalStorage<T>(
       if (item) {
         setStoredValue(JSON.parse(item));
       } else {
-        setStoredValue(initialValue instanceof Function ? initialValue() : initialValue);
+        const value =
+          initialRef.current instanceof Function
+            ? initialRef.current()
+            : initialRef.current;
+        setStoredValue(value);
       }
     } catch (error) {
       console.error(`Error loading ${storageKey} from localStorage:`, error);
     }
-  }, [storageKey, initialValue]);
+  }, [storageKey]);
 
   const setValue = (value: T | ((val: T) => T)) => {
     try {


### PR DESCRIPTION
## Summary
- use `useRef` in `useLocalStorage` to keep initial value stable
- avoid re-running storage sync when initial value changes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68a710e04f4c8323827bb084855f6261