### PR TITLE
Add seat allocation view for worshipers

### DIFF
--- a/src/components/Worshipers/WorshiperManagement.tsx
+++ b/src/components/Worshipers/WorshiperManagement.tsx
@@ -1,12 +1,14 @@
 import React, { useState, useRef } from 'react';
 import { Worshiper } from '../../types';
 import { useAppContext } from '../../context/AppContext';
-import { Plus, Edit2, Trash2, Save, X, User as UserIcon, Upload, Download } from 'lucide-react';
+import { Plus, Edit2, Trash2, Save, X, User as UserIcon, Upload, Download, MapPin } from 'lucide-react';
+import WorshiperSeatsForm from './WorshiperSeatsForm';
 
 const WorshiperManagement: React.FC = () => {
   const { worshipers, setWorshipers } = useAppContext();
   const [isAdding, setIsAdding] = useState(false);
   const [editingWorshiper, setEditingWorshiper] = useState<string | null>(null);
+  const [seatWorshiper, setSeatWorshiper] = useState<Worshiper | null>(null);
   const [formData, setFormData] = useState<Partial<Worshiper>>({
     title: '',
     firstName: '',
@@ -152,6 +154,7 @@ const WorshiperManagement: React.FC = () => {
   };
 
   return (
+    <>
     <div className="space-y-6">
       <div className="flex justify-between items-center">
         <h1 className="text-3xl font-bold text-gray-900">ניהול מתפללים</h1>
@@ -348,6 +351,14 @@ const WorshiperManagement: React.FC = () => {
                   <td className="px-4 py-2">
                     <div className="flex space-x-2 space-x-reverse">
                       <button
+                        onClick={() => setSeatWorshiper(w)}
+                        disabled={isAdding || editingWorshiper}
+                        className="p-2 text-green-600 hover:bg-green-50 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+                        title="מקומות"
+                      >
+                        <MapPin className="h-4 w-4" />
+                      </button>
+                      <button
                         onClick={() => handleEditWorshiper(w)}
                         disabled={isAdding || editingWorshiper}
                         className="p-2 text-blue-600 hover:bg-blue-50 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
@@ -363,11 +374,11 @@ const WorshiperManagement: React.FC = () => {
                       >
                         <Trash2 className="h-4 w-4" />
                       </button>
-                    </div>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
+                      </div>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
           </table>
         </div>
       ) : (
@@ -378,6 +389,13 @@ const WorshiperManagement: React.FC = () => {
         </div>
       )}
     </div>
+    {seatWorshiper && (
+      <WorshiperSeatsForm
+        worshiper={seatWorshiper}
+        onClose={() => setSeatWorshiper(null)}
+      />
+    )}
+    </>
   );
 };
 

--- a/src/components/Worshipers/WorshiperSeatsForm.tsx
+++ b/src/components/Worshipers/WorshiperSeatsForm.tsx
@@ -1,0 +1,57 @@
+import React from 'react';
+import { X } from 'lucide-react';
+import { Worshiper } from '../../types';
+import { useAppContext } from '../../context/AppContext';
+
+interface Props {
+  worshiper: Worshiper;
+  onClose: () => void;
+}
+
+const WorshiperSeatsForm: React.FC<Props> = ({ worshiper, onClose }) => {
+  const { seats, benches } = useAppContext();
+  const userSeats = seats.filter(s => s.userId === worshiper.id);
+
+  const getBenchName = (benchId?: string) =>
+    benches.find(b => b.id === benchId)?.name || '';
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50">
+      <div className="bg-white p-6 rounded-lg shadow-md w-full max-w-md">
+        <div className="flex justify-between items-center mb-4">
+          <h3 className="text-lg font-semibold text-gray-900">
+            המקומות של {worshiper.title} {worshiper.firstName} {worshiper.lastName}
+          </h3>
+          <button
+            onClick={onClose}
+            className="p-1 text-gray-400 hover:text-gray-600"
+          >
+            <X className="h-4 w-4" />
+          </button>
+        </div>
+        {userSeats.length > 0 ? (
+          <ul className="space-y-2">
+            {userSeats.map(seat => (
+              <li key={seat.id} className="flex justify-between">
+                <span>מקום {seat.id}</span>
+                <span>{getBenchName(seat.benchId)}</span>
+              </li>
+            ))}
+          </ul>
+        ) : (
+          <p className="text-gray-600 mb-4">לא הוקצו מקומות למתפלל זה</p>
+        )}
+        <div className="mt-4 flex justify-end">
+          <button
+            onClick={onClose}
+            className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 transition-colors"
+          >
+            סגור
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default WorshiperSeatsForm;


### PR DESCRIPTION
## Summary
- allow viewing seats assigned to each worshiper from the management table
- implement `WorshiperSeatsForm` to list seat locations and bench names

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68aa206b72d083238e9656ed7c8baa1c