### PR TITLE
feat: add seat assignment button for selected seats

### DIFF
--- a/src/components/Seats/SeatsManagement.tsx
+++ b/src/components/Seats/SeatsManagement.tsx
@@ -21,7 +21,8 @@ import {
   BoxSelect,
   ListOrdered,
   Save,
-  Eye
+  Eye,
+  UserCheck
 } from 'lucide-react';
 import MapZoomControls from './MapZoomControls';
 
@@ -1010,6 +1011,15 @@ const SeatsManagement: React.FC = () => {
                 >
                   <Hand className="h-4 w-4" />
                 </button>
+                {selectedSeatIds.length > 0 && (
+                  <button
+                    onClick={() => setShowSeatDetails(true)}
+                    className="p-2 rounded-lg bg-blue-600 text-white hover:bg-blue-700 transition-colors"
+                    title="שייך למתפלל"
+                  >
+                    <UserCheck className="h-4 w-4" />
+                  </button>
+                )}
                   <button
                     onClick={reorderSeatNumbers}
                     className="p-2 rounded-lg bg-yellow-100 text-yellow-600 hover:bg-yellow-200 transition-colors"


### PR DESCRIPTION
## Summary
- add user assignment button to toolbar
- show button only when seats are selected

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa23ac93688323b5339714883595e0