### PR TITLE
feat: auto-save map on position change

### DIFF
--- a/src/components/Seats/SeatsManagement.tsx
+++ b/src/components/Seats/SeatsManagement.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useCallback } from 'react';
+import React, { useState, useCallback, useRef } from 'react';
 import { useAppContext } from '../../context/AppContext';
 import { Seat, Worshiper, Bench, MapBounds } from '../../types';
 import {
@@ -234,6 +234,15 @@ const SeatsManagement: React.FC = () => {
   const [isSelecting, setIsSelecting] = useState(false);
   const [selectionStart, setSelectionStart] = useState<{ x: number; y: number } | null>(null);
   const [selectionRect, setSelectionRect] = useState<{ x: number; y: number; width: number; height: number } | null>(null);
+
+  const isInitialRender = useRef(true);
+  React.useEffect(() => {
+    if (isInitialRender.current) {
+      isInitialRender.current = false;
+      return;
+    }
+    saveCurrentMap();
+  }, [benches, saveCurrentMap]);
 
   const handleSaveMap = () => {
     if (currentMapId) {


### PR DESCRIPTION
## Summary
- auto-save map data whenever bench positions change using React effect

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa287bbbb48323968662c710a489d2