### PR TITLE
feat: add map print option

### DIFF
--- a/src/components/Seats/SeatsManagement.tsx
+++ b/src/components/Seats/SeatsManagement.tsx
@@ -773,6 +773,16 @@ const SeatsManagement: React.FC = () => {
     pdf.save('map.pdf');
   };
 
+  const handlePrintMap = async (id: string) => {
+    const previousId = currentMapId;
+    loadMap(id);
+    await new Promise(resolve => setTimeout(resolve, 100));
+    await exportMapToPDF();
+    if (previousId && previousId !== id) {
+      loadMap(previousId);
+    }
+  };
+
   const assignWorshiperToSeats = (seatIds: number[], worshiperId: string | null) => {
     if (worshiperId) {
       const worshiper = worshipers.find(w => w.id === worshiperId);
@@ -1742,13 +1752,19 @@ const SeatsManagement: React.FC = () => {
                     key={m.id}
                     className={`flex items-center justify-between p-2 rounded ${m.id === currentMapId ? 'bg-blue-100 text-blue-700' : 'bg-gray-100'}`}
                   >
-                    <span className="flex-grow text-right">{m.name}</span>
-                    <div className="flex items-center space-x-1 rtl:space-x-reverse">
+                  <span className="flex-grow text-right">{m.name}</span>
+                  <div className="flex items-center space-x-1 rtl:space-x-reverse">
                       <button
                         onClick={() => loadMap(m.id)}
                         className="p-1 text-blue-600 hover:text-blue-800"
                       >
                         <Eye className="h-4 w-4" />
+                      </button>
+                      <button
+                        onClick={() => handlePrintMap(m.id)}
+                        className="p-1 text-purple-600 hover:text-purple-800"
+                      >
+                        <Printer className="h-4 w-4" />
                       </button>
                       <button
                         onClick={() => handleRenameMap(m.id)}


### PR DESCRIPTION
## Summary
- add print handler for seat maps
- allow printing maps directly from list

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa2d5776788323acca6fa885953255