### PR TITLE
Enhance clarity of map PDF export

### DIFF
--- a/src/components/Seats/SeatsManagement.tsx
+++ b/src/components/Seats/SeatsManagement.tsx
@@ -762,7 +762,12 @@ const SeatsManagement: React.FC = () => {
   const exportMapToPDF = async () => {
     const element = mapRef.current;
     if (!element) return;
-    const canvas = await html2canvas(element, { scale: 2 });
+    const originalShowGrid = gridSettings.showGrid;
+    setGridSettings(prev => ({ ...prev, showGrid: false }));
+    const centerMarker = element.querySelector('.map-center-marker') as HTMLElement | null;
+    if (centerMarker) centerMarker.style.display = 'none';
+    await new Promise(resolve => setTimeout(resolve, 0));
+    const canvas = await html2canvas(element, { scale: 3, backgroundColor: '#ffffff' });
     const orientation = canvas.width > canvas.height ? 'landscape' : 'portrait';
     const pdf = new jsPDF({
       orientation,
@@ -771,6 +776,8 @@ const SeatsManagement: React.FC = () => {
     });
     pdf.addImage(canvas.toDataURL('image/png'), 'PNG', 0, 0, canvas.width, canvas.height);
     pdf.save('map.pdf');
+    setGridSettings(prev => ({ ...prev, showGrid: originalShowGrid }));
+    if (centerMarker) centerMarker.style.display = '';
   };
 
   const handlePrintMap = async (id: string) => {
@@ -1137,7 +1144,7 @@ const SeatsManagement: React.FC = () => {
                 {renderGrid()}
 
                 {/* סימון מרכז המפה */}
-                <div className="absolute left-1/2 top-1/2 w-4 h-4 bg-red-500 rounded-full border-2 border-white transform -translate-x-1/2 -translate-y-1/2 pointer-events-none z-50" />
+                <div className="absolute left-1/2 top-1/2 w-4 h-4 bg-red-500 rounded-full border-2 border-white transform -translate-x-1/2 -translate-y-1/2 pointer-events-none z-50 map-center-marker" />
 
                 {/* רינדור ספסלים */}
                 {benches.map((bench) => (


### PR DESCRIPTION
## Summary
- Remove grid and center marker when exporting map to PDF
- Increase canvas scale and use white background for clearer PDFs

## Testing
- `npm test` *(fails: Missing script "test"?)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa348ca4888323afa8e408f654d9a8