### PR TITLE
Hide map management icons in PDF export

### DIFF
--- a/src/components/Seats/MapZoomControls.tsx
+++ b/src/components/Seats/MapZoomControls.tsx
@@ -10,7 +10,7 @@ const MapZoomControls: React.FC<MapZoomControlsProps> = ({ setZoom }) => {
   const zoomOut = () => setZoom(prev => Math.max(prev - 0.1, 0.5));
 
   return (
-    <div className="absolute top-4 left-4 flex flex-col bg-white rounded shadow-md z-50">
+    <div className="absolute top-4 left-4 flex flex-col bg-white rounded shadow-md z-50 print-hidden">
       <button
         onClick={zoomIn}
         className="p-2 hover:bg-gray-100 border-b"

--- a/src/components/Seats/SeatsManagement.tsx
+++ b/src/components/Seats/SeatsManagement.tsx
@@ -765,8 +765,12 @@ const SeatsManagement: React.FC = () => {
     if (!element) return;
     const originalShowGrid = gridSettings.showGrid;
     setGridSettings(prev => ({ ...prev, showGrid: false }));
-    const centerMarker = element.querySelector('.map-center-marker') as HTMLElement | null;
-    if (centerMarker) centerMarker.style.display = 'none';
+    const hiddenElements = Array.from(
+      element.querySelectorAll('.print-hidden')
+    ) as HTMLElement[];
+    hiddenElements.forEach(el => {
+      el.style.display = 'none';
+    });
     await new Promise(resolve => setTimeout(resolve, 0));
     const canvas = await html2canvas(element, { scale: 3, backgroundColor: '#ffffff' });
     const orientation = canvas.width > canvas.height ? 'landscape' : 'portrait';
@@ -778,7 +782,9 @@ const SeatsManagement: React.FC = () => {
     pdf.addImage(canvas.toDataURL('image/png'), 'PNG', 0, 0, canvas.width, canvas.height);
     pdf.save('map.pdf');
     setGridSettings(prev => ({ ...prev, showGrid: originalShowGrid }));
-    if (centerMarker) centerMarker.style.display = '';
+    hiddenElements.forEach(el => {
+      el.style.display = '';
+    });
   };
 
   const handlePrintMap = async (id: string) => {
@@ -1146,7 +1152,7 @@ const SeatsManagement: React.FC = () => {
                 {renderGrid()}
 
                 {/* סימון מרכז המפה */}
-                <div className="absolute left-1/2 top-1/2 w-4 h-4 bg-red-500 rounded-full border-2 border-white transform -translate-x-1/2 -translate-y-1/2 pointer-events-none z-50 map-center-marker" />
+                <div className="absolute left-1/2 top-1/2 w-4 h-4 bg-red-500 rounded-full border-2 border-white transform -translate-x-1/2 -translate-y-1/2 pointer-events-none z-50 map-center-marker print-hidden" />
 
                 {/* רינדור ספסלים */}
                 {benches.map((bench) => (
@@ -1177,13 +1183,13 @@ const SeatsManagement: React.FC = () => {
                       e.stopPropagation();
                       setOpenSettingsId(openSettingsId === bench.id ? null : bench.id);
                     }}
-                    className="absolute top-1 left-1 z-[50] p-1 bg-white rounded shadow-md hover:bg-gray-50 transition-colors"
+                    className="absolute top-1 left-1 z-[50] p-1 bg-white rounded shadow-md hover:bg-gray-50 transition-colors print-hidden"
                     title="הגדרות"
                   >
                     <Settings className="h-3 w-3 text-gray-600" />
                   </button>
                   {openSettingsId === bench.id && (
-                    <div className="absolute top-1 left-7 z-[60] flex space-x-1 space-x-reverse p-1 bg-white rounded shadow-md">
+                    <div className="absolute top-1 left-7 z-[60] flex space-x-1 space-x-reverse p-1 bg-white rounded shadow-md print-hidden">
                       <button
                         onClick={(e) => {
                           e.stopPropagation();
@@ -1260,19 +1266,19 @@ const SeatsManagement: React.FC = () => {
                     <>
                       <div
                         onMouseDown={(e) => handleResizeMouseDown(e, bench.id, 'right')}
-                        className="absolute top-1/2 -right-3 p-0.5 bg-blue-500 text-white cursor-e-resize transform -translate-y-1/2"
+                        className="absolute top-1/2 -right-3 p-0.5 bg-blue-500 text-white cursor-e-resize transform -translate-y-1/2 print-hidden"
                       >
                         <ArrowRight className="h-3 w-3" />
                       </div>
                       <div
                         onMouseDown={(e) => handleResizeMouseDown(e, bench.id, 'bottom')}
-                        className="absolute left-1/2 -bottom-3 p-0.5 bg-blue-500 text-white cursor-s-resize transform -translate-x-1/2"
+                        className="absolute left-1/2 -bottom-3 p-0.5 bg-blue-500 text-white cursor-s-resize transform -translate-x-1/2 print-hidden"
                       >
                         <ArrowDown className="h-3 w-3" />
                       </div>
                       <div
                         onMouseDown={(e) => handleResizeMouseDown(e, bench.id, 'corner')}
-                        className="absolute -bottom-3 -right-3 p-0.5 bg-blue-500 text-white cursor-se-resize"
+                        className="absolute -bottom-3 -right-3 p-0.5 bg-blue-500 text-white cursor-se-resize print-hidden"
                       >
                         <ArrowDownRight className="h-3 w-3" />
                       </div>


### PR DESCRIPTION
## Summary
- hide zoom and bench setting controls from PDF output
- generalize map export to suppress all `.print-hidden` UI elements

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build` *(fails: Rollup failed to resolve import "html2canvas"; npm install failed with 403)*

------
https://chatgpt.com/codex/tasks/task_e_68aa361e0aec8323b68d1197711a6b86