### PR TITLE
Enable automatic horizontal map expansion

### DIFF
--- a/src/components/Seats/SeatsManagement.tsx
+++ b/src/components/Seats/SeatsManagement.tsx
@@ -1128,7 +1128,7 @@ const SeatsManagement: React.FC = () => {
 
             <div
               className={`relative border-2 border-dashed border-gray-300 rounded-lg bg-gray-50 overflow-hidden ${isPanMode ? (isPanning ? 'cursor-grabbing' : 'cursor-grab') : ''}`}
-              style={{ width: 1200 + mapBounds.left + mapBounds.right, height: 800 + mapBounds.top + mapBounds.bottom, maxWidth: '100%' }}
+              style={{ width: 1200 + mapBounds.left + mapBounds.right, height: 800 + mapBounds.top + mapBounds.bottom }}
               onDrop={handleDrop}
               onDragOver={handleDragOver}
               onContextMenu={handleContextMenu}


### PR DESCRIPTION
## Summary
- allow map container width to grow by removing `maxWidth` restriction

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68aa36deb0648323afc9e2b221fffba5