### PR TITLE
Limit map modal width to 70%

### DIFF
--- a/src/components/Contact/Contact.tsx
+++ b/src/components/Contact/Contact.tsx
@@ -5,7 +5,8 @@ import { ContactForm } from '../../types';
 
 // Dimensions for the map modal. This controls the area on the screen where
 // the embedded map is rendered so its size can be easily adjusted in one place.
-const MAP_MODAL_WIDTH = 800;
+// Use a percentage for the width so the map never exceeds 70% of the page width.
+const MAP_MODAL_WIDTH = '70%';
 const MAP_MODAL_HEIGHT = 450;
 
 const Contact: React.FC = () => {


### PR DESCRIPTION
## Summary
- Limit embedded map modal to at most 70% of page width

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa3bc035ac8323bdffc7c6a41f01ae