### PR TITLE
Use map name for PDF and reduce size

### DIFF
--- a/src/components/Seats/SeatsManagement.tsx
+++ b/src/components/Seats/SeatsManagement.tsx
@@ -782,7 +782,7 @@ const SeatsManagement: React.FC = () => {
     });
     await new Promise(resolve => setTimeout(resolve, 0));
     const canvas = await html2canvas(element, {
-      scale: 2,
+      scale: 1,
       backgroundColor: '#ffffff',
     });
     const orientation = canvas.width > canvas.height ? 'landscape' : 'portrait';
@@ -794,7 +794,8 @@ const SeatsManagement: React.FC = () => {
     });
     const imgData = canvas.toDataURL('image/jpeg', 0.7);
     pdf.addImage(imgData, 'JPEG', 0, 0, canvas.width, canvas.height, undefined, 'FAST');
-    pdf.save('map.pdf');
+    const fileName = (currentMap?.name ? currentMap.name.replace(/\s+/g, '_') : 'map') + '.pdf';
+    pdf.save(fileName);
     setGridSettings(prev => ({ ...prev, showGrid: originalShowGrid }));
     hiddenElements.forEach(el => {
       el.style.display = '';


### PR DESCRIPTION
## Summary
- Save exported map PDFs using the current map's name
- Reduce PDF export size by capturing at 1x scale

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/html2canvas)*

------
https://chatgpt.com/codex/tasks/task_e_68aadc6a77ac8323b539490115db55d5