### PR TITLE
feat: add black and white PDF export

### DIFF
--- a/src/components/Seats/SeatsManagement.tsx
+++ b/src/components/Seats/SeatsManagement.tsx
@@ -766,19 +766,12 @@ const SeatsManagement: React.FC = () => {
     if (!element) return;
     const originalShowGrid = gridSettings.showGrid;
     setGridSettings(prev => ({ ...prev, showGrid: false }));
+    element.classList.add('pdf-export');
     const hiddenElements = Array.from(
       element.querySelectorAll('.print-hidden')
     ) as HTMLElement[];
     hiddenElements.forEach(el => {
       el.style.display = 'none';
-    });
-    const shadowElements = Array.from(
-      element.querySelectorAll('[class*="shadow"]')
-    ) as HTMLElement[];
-    const boxShadowMap = new Map<HTMLElement, string>();
-    shadowElements.forEach(el => {
-      boxShadowMap.set(el, el.style.boxShadow);
-      el.style.boxShadow = 'none';
     });
     await new Promise(resolve => setTimeout(resolve, 0));
     const canvas = await html2canvas(element, {
@@ -796,14 +789,9 @@ const SeatsManagement: React.FC = () => {
     pdf.addImage(imgData, 'JPEG', 0, 0, canvas.width, canvas.height, undefined, 'FAST');
     pdf.save('map.pdf');
     setGridSettings(prev => ({ ...prev, showGrid: originalShowGrid }));
+    element.classList.remove('pdf-export');
     hiddenElements.forEach(el => {
       el.style.display = '';
-    });
-    shadowElements.forEach(el => {
-      const original = boxShadowMap.get(el);
-      if (original !== undefined) {
-        el.style.boxShadow = original;
-      }
     });
   };
 

--- a/src/index.css
+++ b/src/index.css
@@ -1,3 +1,18 @@
 @tailwind base;
 @tailwind components;
 @tailwind utilities;
+
+/* Styles applied during PDF export to produce a clean black and white map */
+.pdf-export {
+  filter: grayscale(100%) contrast(200%);
+}
+
+.pdf-export *,
+.pdf-export *::before,
+.pdf-export *::after {
+  box-shadow: none !important;
+  background: #ffffff !important;
+  color: #000000 !important;
+  border-color: #000000 !important;
+  border-radius: 6px !important;
+}


### PR DESCRIPTION
## Summary
- add PDF export styling for simple black & white output with rounded edges
- apply temporary styling during export to remove shadows and colors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aade87f7788323acc7861b51cfd940