### PR TITLE
feat: enlarge seat worshipper text

### DIFF
--- a/src/components/Seats/SeatsManagement.tsx
+++ b/src/components/Seats/SeatsManagement.tsx
@@ -1414,8 +1414,10 @@ const SeatsManagement: React.FC = () => {
                           }}
                           title={status.worshiper ? `${status.worshiper.title} ${status.worshiper.firstName} ${status.worshiper.lastName}` : 'פנוי'}
                         >
-                          <div className="text-white font-bold text-[7px] leading-tight text-center px-1">
-                            {status.worshiper ? `${status.worshiper.title} ${status.worshiper.firstName} ${status.worshiper.lastName}` : 'פנוי'}
+                          <div className="text-white font-medium text-[10px] leading-tight text-center px-1">
+                            {status.worshiper
+                              ? `${status.worshiper.title} ${status.worshiper.firstName} ${status.worshiper.lastName}`
+                              : 'פנוי'}
                           </div>
                           
                           {status.worshiper && (


### PR DESCRIPTION
## Summary
- enlarge worshipper names shown on seating map for better readability

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/html2canvas)


------
https://chatgpt.com/codex/tasks/task_e_68ab0687a208832395ec93fd015c44d7