### PR TITLE
style: center text and add body padding

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,10 @@
 @tailwind components;
 @tailwind utilities;
 
+body {
+  @apply p-4 text-center;
+}
+
 /* Styles applied during PDF export to produce a clean black and white map */
 .pdf-export {
   filter: grayscale(100%) contrast(200%);


### PR DESCRIPTION
## Summary
- add global body padding so text doesn't touch edges
- center text across the app by default

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js'; npm install also failed with 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ab0dacc1448323940cdb389f4ed269