### PR TITLE
Trim map whitespace when saving or printing

### DIFF
--- a/src/components/Seats/SeatsManagement.tsx
+++ b/src/components/Seats/SeatsManagement.tsx
@@ -186,6 +186,7 @@ const SeatsManagement: React.FC = () => {
     loadMap,
     currentMapId,
     renameMap,
+    trimMap,
   } = useAppContext();
   const mapRef = useRef<HTMLDivElement>(null);
   const currentMap = maps.find(m => m.id === currentMapId);
@@ -764,6 +765,8 @@ const SeatsManagement: React.FC = () => {
   };
 
   const exportMapToPDF = async (isColor = false) => {
+    trimMap();
+    await new Promise(resolve => setTimeout(resolve, 0));
     const element = mapRef.current;
     if (!element) return;
     const originalShowGrid = gridSettings.showGrid;


### PR DESCRIPTION
## Summary
- add trimming logic that removes blank map areas and leaves 1.5cm margins
- ensure trimming happens on save and before exporting to PDF

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68ab0e7907588323ae4eaf1231b8d6f6