### PR TITLE
Add side margins for label PDF export

### DIFF
--- a/src/components/Seats/SeatsManagement.tsx
+++ b/src/components/Seats/SeatsManagement.tsx
@@ -843,11 +843,15 @@ const SeatsManagement: React.FC = () => {
     }
 
     const doc = new jsPDF({ orientation: 'portrait', unit: 'mm', format: 'a4', compress: false });
-    const labelWidth = 70;
+    const pageWidth = doc.internal.pageSize.getWidth();
     const labelHeight = 35;
     const cols = 3;
     const rowsPerPage = 8;
-    const topMargin = (297 - rowsPerPage * labelHeight) / 2; // center vertically
+
+    // שמירה על שוליים בצדדים וסידור התוויות במרכז העמוד
+    const horizontalMargin = 10; // מ"מ
+    const labelWidth = (pageWidth - horizontalMargin * 2) / cols;
+    const topMargin = (297 - rowsPerPage * labelHeight) / 2; // מרכז אנכית
 
     labeledSeats.forEach((seat, index) => {
       const position = index % (cols * rowsPerPage);
@@ -856,7 +860,7 @@ const SeatsManagement: React.FC = () => {
       }
       const row = Math.floor(position / cols);
       const col = position % cols;
-      const x = col * labelWidth;
+      const x = horizontalMargin + col * labelWidth;
       const y = topMargin + row * labelHeight;
 
       doc.rect(x, y, labelWidth, labelHeight);


### PR DESCRIPTION
## Summary
- ensure label PDFs have horizontal margins and centered content to avoid touching page edges

## Testing
- `npm test` *(fails: Missing script "test"*)
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ab0fe577f08323ad4b212990c557d9