### PR TITLE
fix: allow map to expand upward and left

### DIFF
--- a/src/components/Seats/SeatsManagement.tsx
+++ b/src/components/Seats/SeatsManagement.tsx
@@ -89,6 +89,7 @@ const specialElements = [
 ];
 
 const MIN_BENCH_SPACING = 20;
+const MAP_EXPANSION_MARGIN = 20;
 
 const getBenchDimensions = (bench: Bench) => {
   if (bench.type === 'special') {
@@ -305,10 +306,16 @@ const SeatsManagement: React.FC = () => {
 
         benchesToCheck.forEach(b => {
           const { width, height } = getBenchDimensions(b);
-          left = Math.max(left, Math.max(0, -b.position.x));
-          top = Math.max(top, Math.max(0, -b.position.y));
-          right = Math.max(right, Math.max(0, b.position.x + width - rect.width));
-          bottom = Math.max(bottom, Math.max(0, b.position.y + height - rect.height));
+          left = Math.max(left, Math.max(0, -b.position.x + MAP_EXPANSION_MARGIN));
+          top = Math.max(top, Math.max(0, -b.position.y + MAP_EXPANSION_MARGIN));
+          right = Math.max(
+            right,
+            Math.max(0, b.position.x + width - rect.width + MAP_EXPANSION_MARGIN)
+          );
+          bottom = Math.max(
+            bottom,
+            Math.max(0, b.position.y + height - rect.height + MAP_EXPANSION_MARGIN)
+          );
         });
 
         return { left, top, right, bottom };


### PR DESCRIPTION
## Summary
- add expansion margin to map bounds logic
- ensure benches can extend map upward and left

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68ab7aaf129c832399ef4b9657e0551f