### PR TITLE
Align zoom limits and make map view responsive

### DIFF
--- a/src/components/Seats/MapZoomControls.tsx
+++ b/src/components/Seats/MapZoomControls.tsx
@@ -4,11 +4,13 @@ import { Plus, Minus, Maximize } from 'lucide-react';
 interface MapZoomControlsProps {
   setZoom: React.Dispatch<React.SetStateAction<number>>;
   onFit?: () => void;
+  min?: number;
+  max?: number;
 }
 
-const MapZoomControls: React.FC<MapZoomControlsProps> = ({ setZoom, onFit }) => {
-  const zoomIn = () => setZoom(prev => Math.min(prev + 0.1, 2));
-  const zoomOut = () => setZoom(prev => Math.max(prev - 0.1, 0.5));
+const MapZoomControls: React.FC<MapZoomControlsProps> = ({ setZoom, onFit, min = 0.3, max = 3 }) => {
+  const zoomIn = () => setZoom(prev => Math.min(prev + 0.1, max));
+  const zoomOut = () => setZoom(prev => Math.max(prev - 0.1, min));
 
   return (
     <div className="flex items-center space-x-2 space-x-reverse">

--- a/src/components/Seats/SeatsManagement.tsx
+++ b/src/components/Seats/SeatsManagement.tsx
@@ -1329,7 +1329,7 @@ const SeatsManagement: React.FC = () => {
                   >
                     <Trash2 className="h-4 w-4" />
                 </button>
-                  <MapZoomControls setZoom={setZoom} onFit={handleFitToScreen} />
+                  <MapZoomControls setZoom={setZoom} onFit={handleFitToScreen} min={MIN_ZOOM} max={MAX_ZOOM} />
               </div>
             </div>
 


### PR DESCRIPTION
## Summary
- Add optional min/max zoom props to MapZoomControls and wire up from SeatsManagement for consistent bounds
- Replace hard-coded MapView dimensions with ResizeObserver-driven base size

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68ac6cb230f08323925dcae1e9910312