### PR TITLE
Disable transforms during PDF export

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -8,6 +8,7 @@ body {
 
 /* Styles applied during PDF export to produce a clean black and white map */
 .pdf-export {
+  transform: none !important;
   filter: grayscale(100%) contrast(200%);
 }
 


### PR DESCRIPTION
## Summary
- ensure map captures full extent by disabling transforms when `.pdf-export` is applied

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68ac920d4c7083239d2a635ddace0cd5