### PR TITLE
feat: add pdf export toolbar

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -6,18 +6,7 @@ body {
   @apply p-4 text-center;
 }
 
-/* Styles applied during PDF export to produce a clean black and white map */
+/* Removes transforms during PDF export */
 .pdf-export {
   transform: none !important;
-  filter: grayscale(100%) contrast(200%);
-}
-
-.pdf-export *,
-.pdf-export *::before,
-.pdf-export *::after {
-  box-shadow: none !important;
-  background: #ffffff !important;
-  color: #000000 !important;
-  border-color: #000000 !important;
-  border-radius: 6px !important;
 }


### PR DESCRIPTION
## Summary
- streamline PDF export by adding html2canvas/jsPDF utilities with grayscale support
- introduce PdfToolbar with color and layout options
- simplify global `.pdf-export` CSS override

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68ac94a28bdc8323adc6a56e61f0e37c