### PR TITLE
feat: add public home page

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -12,12 +12,14 @@ import Login from './components/Auth/Login';
 import RequireAuth from './components/Auth/RequireAuth';
 import MapView from './components/Seats/MapView';
 import Pricing from './components/Pricing/Pricing';
+import Home from './components/Home/Home';
 
 function App() {
   return (
     <AuthProvider>
       <Router>
         <Routes>
+          <Route path="/" element={<Home />} />
           <Route path="/login" element={<Login />} />
           <Route
             path="/view/:id"
@@ -28,7 +30,7 @@ function App() {
             }
           />
           <Route
-            path="/"
+            path="/app"
             element={
               <RequireAuth>
                 <AppProvider>

--- a/src/components/Auth/Login.tsx
+++ b/src/components/Auth/Login.tsx
@@ -17,7 +17,7 @@ const Login: React.FC = () => {
         register(username, password);
       }
       login(username, password);
-      navigate('/');
+      navigate('/app');
     } catch (err) {
       setError((err as Error).message);
     }

--- a/src/components/Home/Home.tsx
+++ b/src/components/Home/Home.tsx
@@ -1,0 +1,29 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import { Armchair, ArrowRight } from 'lucide-react';
+
+const Home: React.FC = () => {
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gradient-to-br from-blue-50 to-indigo-100" dir="rtl">
+      <div className="max-w-3xl mx-auto p-8 text-center space-y-6 bg-white rounded-lg shadow">
+        <div className="flex justify-center">
+          <Armchair className="h-16 w-16 text-blue-600" />
+        </div>
+        <h1 className="text-4xl font-bold text-gray-900">מערכת ניהול מקומות ישיבה</h1>
+        <p className="text-xl text-gray-700">
+          ברוכים הבאים! זוהי מערכת מקיפה לניהול מקומות ישיבה במשרדים ובחללי עבודה, הכוללת
+          כלי גרירה ושחרור, ניהול מתפללים ומפה אינטואיטיבית בעברית מלאה.
+        </p>
+        <Link
+          to="/login"
+          className="inline-flex items-center px-6 py-3 bg-blue-600 text-white rounded-lg text-lg font-medium hover:bg-blue-700 transition-colors"
+        >
+          התחבר למערכת
+          <ArrowRight className="mr-2 h-5 w-5" />
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export default Home;

--- a/src/components/Layout/Navbar.tsx
+++ b/src/components/Layout/Navbar.tsx
@@ -17,12 +17,12 @@ const Navbar: React.FC = () => {
   const { logout } = useAuth();
 
   const navItems = [
-    { path: '/', label: 'ניהול מתפללים', icon: Users },
-    { path: '/seats-manage', label: 'ניהול מקומות', icon: Settings },
-    { path: '/map-guide', label: 'מדריך מפה', icon: HelpCircle },
-    { path: '/contact', label: 'צור קשר', icon: Mail },
-    { path: '/about', label: 'אודות', icon: Info },
-    { path: '/pricing', label: 'מחירון', icon: CreditCard },
+    { path: '/app', label: 'ניהול מתפללים', icon: Users },
+    { path: '/app/seats-manage', label: 'ניהול מקומות', icon: Settings },
+    { path: '/app/map-guide', label: 'מדריך מפה', icon: HelpCircle },
+    { path: '/app/contact', label: 'צור קשר', icon: Mail },
+    { path: '/app/about', label: 'אודות', icon: Info },
+    { path: '/app/pricing', label: 'מחירון', icon: CreditCard },
   ];
 
   return (


### PR DESCRIPTION
## Summary
- add a descriptive landing page for the seat management system
- move authenticated pages under `/app` and update navigation
- redirect users to the app after login

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js'; npm install also failed with 403)*

------
https://chatgpt.com/codex/tasks/task_e_68ad787e7ad08323b27ac32c4b2a1f8f