### PR TITLE
feat: add plan selection buttons

### DIFF
--- a/src/components/Pricing/Pricing.tsx
+++ b/src/components/Pricing/Pricing.tsx
@@ -25,6 +25,8 @@ const plans = [
 ];
 
 const Pricing: React.FC = () => {
+  const [selectedPlan, setSelectedPlan] = React.useState<string | null>(null);
+
   return (
     <div className="max-w-5xl mx-auto space-y-12 py-16">
       <div className="text-center">
@@ -33,45 +35,60 @@ const Pricing: React.FC = () => {
       </div>
 
       <div className="grid grid-cols-1 gap-8 md:grid-cols-2">
-        {plans.map((plan) => (
-          <div
-            key={plan.name}
-            className={`flex flex-col rounded-2xl border p-8 shadow-sm transition hover:-translate-y-1 hover:shadow-xl bg-white ${
-              plan.name === 'פרו' ? 'border-blue-500 ring-2 ring-blue-200' : 'border-gray-200'
-            }`}
-          >
-            <div className="relative mb-6 text-center">
-              {plan.name === 'פרו' && (
-                <span className="absolute -top-4 left-1/2 -translate-x-1/2 rounded-full bg-blue-600 px-3 py-1 text-xs font-medium text-white">
-                  הכי פופולרי
-                </span>
+        {plans.map((plan) => {
+          const isSelected = selectedPlan === plan.name;
+
+          return (
+            <div
+              key={plan.name}
+              className={`flex flex-col rounded-2xl border p-8 shadow-sm transition hover:-translate-y-1 hover:shadow-xl bg-white ${
+                isSelected
+                  ? 'border-blue-600 ring-2 ring-blue-300'
+                  : plan.name === 'פרו'
+                    ? 'border-blue-500 ring-2 ring-blue-200'
+                    : 'border-gray-200'
+              }`}
+            >
+              <div className="relative mb-6 text-center">
+                {plan.name === 'פרו' && (
+                  <span className="absolute -top-4 left-1/2 -translate-x-1/2 rounded-full bg-blue-600 px-3 py-1 text-xs font-medium text-white">
+                    הכי פופולרי
+                  </span>
+                )}
+                <h2 className="mb-2 text-2xl font-bold text-gray-900">{plan.name}</h2>
+                <div className="text-3xl font-extrabold text-blue-600">
+                  {plan.price}
+                  <span className="ml-1 text-base font-normal text-gray-600">
+                    {plan.period}
+                  </span>
+                </div>
+              </div>
+              <ul className="flex-1 space-y-2 text-gray-700">
+                {plan.features.map((feature) => (
+                  <li
+                    key={feature}
+                    className="flex items-center gap-2 rtl:space-x-reverse"
+                  >
+                    <Check className="h-5 w-5 flex-shrink-0 text-blue-600" />
+                    <span>{feature}</span>
+                  </li>
+                ))}
+              </ul>
+              {plan.note && (
+                <div className="mt-6 text-center text-sm text-gray-500">
+                  {plan.note}
+                </div>
               )}
-              <h2 className="mb-2 text-2xl font-bold text-gray-900">{plan.name}</h2>
-              <div className="text-3xl font-extrabold text-blue-600">
-                {plan.price}
-                <span className="ml-1 text-base font-normal text-gray-600">
-                  {plan.period}
-                </span>
-              </div>
+              <button
+                type="button"
+                onClick={() => setSelectedPlan(plan.name)}
+                className="mt-6 rounded-md bg-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-blue-700"
+              >
+                {isSelected ? 'נבחר' : 'בחרו'}
+              </button>
             </div>
-            <ul className="flex-1 space-y-2 text-gray-700">
-              {plan.features.map((feature) => (
-                <li
-                  key={feature}
-                  className="flex items-center gap-2 rtl:space-x-reverse"
-                >
-                  <Check className="h-5 w-5 flex-shrink-0 text-blue-600" />
-                  <span>{feature}</span>
-                </li>
-              ))}
-            </ul>
-            {plan.note && (
-              <div className="mt-6 text-center text-sm text-gray-500">
-                {plan.note}
-              </div>
-            )}
-          </div>
-        ))}
+          );
+        })}
       </div>
     </div>
   );


### PR DESCRIPTION
## Summary
- allow users to select a plan on the pricing page
- highlight the chosen plan and show a selection button on each pricing card

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68adb407056c8323a65721f77e74350d