### PR TITLE
feat: persist maps on server

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 bis
+
+## Storage Server
+
+This project now includes a small file-based storage server used to persist map data on the server rather than in the browser's local storage. This allows maps for each account to be accessed from anywhere.
+
+### Run the server
+
+```
+npm run server
+```
+
+The client uses `useServerStorage` to communicate with the server at `http://localhost:3001`.

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "server": "node server/storageServer.js"
   },
   "dependencies": {
     "lucide-react": "^0.344.0",

--- a/server/storageServer.js
+++ b/server/storageServer.js
@@ -1,0 +1,52 @@
+import { createServer } from 'node:http';
+import { promises as fs, existsSync, mkdirSync } from 'node:fs';
+import { join } from 'node:path';
+
+const dataDir = join(process.cwd(), 'server', 'data');
+if (!existsSync(dataDir)) {
+  mkdirSync(dataDir, { recursive: true });
+}
+
+const server = createServer(async (req, res) => {
+  const url = req.url || '';
+  if (!url.startsWith('/api/storage/')) {
+    res.statusCode = 404;
+    res.end('Not found');
+    return;
+  }
+  const key = url.replace('/api/storage/', '');
+  const filePath = join(dataDir, `${key}.json`);
+
+  if (req.method === 'GET') {
+    try {
+      const data = await fs.readFile(filePath, 'utf-8');
+      res.setHeader('Content-Type', 'application/json');
+      res.end(data);
+    } catch {
+      res.setHeader('Content-Type', 'application/json');
+      res.end('null');
+    }
+    return;
+  }
+
+  if (req.method === 'POST') {
+    let body = '';
+    req.on('data', chunk => {
+      body += chunk;
+    });
+    req.on('end', async () => {
+      await fs.writeFile(filePath, body);
+      res.statusCode = 204;
+      res.end();
+    });
+    return;
+  }
+
+  res.statusCode = 405;
+  res.end();
+});
+
+const PORT = process.env.PORT || 3001;
+server.listen(PORT, () => {
+  console.log(`Storage server running on port ${PORT}`);
+});

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -10,6 +10,7 @@ import {
   MapTemplate,
 } from '../types';
 import { useLocalStorage } from '../hooks/useLocalStorage';
+import { useServerStorage } from '../hooks/useServerStorage';
 import { useAuth } from './AuthContext';
 
 interface AppContextType {
@@ -270,8 +271,8 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
   const [benches, setBenches] = useLocalStorage<Bench[]>('benches', initialBenches, userKey);
   const [seats, setSeats] = useLocalStorage<Seat[]>('seats', initialSeats, userKey);
 
-  const [maps, setMaps] = useLocalStorage<MapData[]>('maps', [defaultMap], userKey);
-  const [currentMapId, setCurrentMapId] = useLocalStorage<string>('currentMapId', defaultMap.id, userKey);
+  const [maps, setMaps] = useServerStorage<MapData[]>('maps', [defaultMap], userKey);
+  const [currentMapId, setCurrentMapId] = useServerStorage<string>('currentMapId', defaultMap.id, userKey);
 
   const defaultTemplate: MapTemplate = {
     id: 'default',

--- a/src/hooks/useServerStorage.ts
+++ b/src/hooks/useServerStorage.ts
@@ -1,0 +1,46 @@
+import { useState, useEffect, useRef } from 'react';
+
+export function useServerStorage<T>(
+  key: string,
+  initialValue: T | (() => T),
+  userId?: string
+): [T, (value: T | ((val: T) => T)) => void] {
+  const storageKey = userId ? `${userId}-${key}` : key;
+  const initialRef = useRef(initialValue);
+  const [storedValue, setStoredValue] = useState<T>(() => {
+    return initialRef.current instanceof Function
+      ? initialRef.current()
+      : initialRef.current;
+  });
+
+  useEffect(() => {
+    const fetchValue = async () => {
+      try {
+        const res = await fetch(`http://localhost:3001/api/storage/${storageKey}`);
+        if (res.ok) {
+          const data = await res.json();
+          if (data !== null) {
+            setStoredValue(data);
+          }
+        }
+      } catch (error) {
+        console.error(`Error loading ${storageKey} from server:`, error);
+      }
+    };
+    fetchValue();
+  }, [storageKey]);
+
+  const setValue = (value: T | ((val: T) => T)) => {
+    const valueToStore = value instanceof Function ? value(storedValue) : value;
+    setStoredValue(valueToStore);
+    fetch(`http://localhost:3001/api/storage/${storageKey}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(valueToStore),
+    }).catch(error => {
+      console.error(`Error saving ${storageKey} to server:`, error);
+    });
+  };
+
+  return [storedValue, setValue];
+}


### PR DESCRIPTION
## Summary
- store map data on a simple file-based server
- add `useServerStorage` hook and use it for map persistence
- document how to run the new storage server

## Testing
- `npm install` *(fails: ENOTEMPTY: directory not empty, rename '/workspace/bis/node_modules/fast-glob' -> '/workspace/bis/node_modules/.fast-glob-Bj0jECfc')*
- `npm run lint` *(fails: Cannot find package '/workspace/bis/node_modules/@eslint/js/index.js')*

------
https://chatgpt.com/codex/tasks/task_e_68aeeb3b2a988323aaee4deee302fce8