### PR TITLE
feat: add new logo component

### DIFF
--- a/src/components/Home/Home.tsx
+++ b/src/components/Home/Home.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import { Link } from "react-router-dom";
 import { Armchair, ArrowRight, Users, Zap, Sparkles } from "lucide-react";
+import Logo from "../common/Logo";
 
 const Home: React.FC = () => {
   const features = [
@@ -47,12 +48,8 @@ const Home: React.FC = () => {
       <div className="max-w-7xl mx-auto px-4 space-y-24">
         {/* Hero */}
         <section className="text-center space-y-8">
-          <div className="flex justify-center">
-            <img
-              src="/logo.svg"
-              alt="Logo"
-              className="h-20 w-20 drop-shadow-md animate-bounce"
-            />
+          <div className="flex justify-center drop-shadow-md animate-bounce">
+            <Logo />
           </div>
           <h1
             className="text-5xl font-extrabold text-gray-900 tracking-tight opacity-0 animate-fade-in-up"

--- a/src/components/Layout/Navbar.tsx
+++ b/src/components/Layout/Navbar.tsx
@@ -9,6 +9,7 @@ import {
   CreditCard
 } from 'lucide-react';
 import { useAuth } from '../../context/AuthContext';
+import Logo from '../common/Logo';
 
 const Navbar: React.FC = () => {
   const navigate = useNavigate();
@@ -28,10 +29,7 @@ const Navbar: React.FC = () => {
     <nav className="bg-white shadow-lg border-b">
       <div className="container mx-auto px-4">
         <div className="flex justify-between items-center h-16">
-          <div className="flex items-center space-x-4 space-x-reverse">
-            <img src="/logo.svg" alt="Logo" className="h-8 w-8" />
-            <h1 className="text-xl font-bold text-gray-800">מערכת ניהול מקומות ישיבה</h1>
-          </div>
+          <Logo />
           
           <div className="flex space-x-1 space-x-reverse items-center">
             {navItems.map((item) => {

--- a/src/components/common/Logo.tsx
+++ b/src/components/common/Logo.tsx
@@ -1,0 +1,32 @@
+import React from 'react';
+
+export default function Logo() {
+  return (
+    <div className="flex items-center gap-2">
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        width="40"
+        height="40"
+        viewBox="0 0 100 100"
+      >
+        {/* רשת של כיסאות */}
+        <rect x="10" y="10" width="20" height="20" rx="4" fill="#2563eb" />
+        <rect x="40" y="10" width="20" height="20" rx="4" fill="#2563eb" />
+        <rect x="70" y="10" width="20" height="20" rx="4" fill="#2563eb" />
+
+        <rect x="10" y="40" width="20" height="20" rx="4" fill="#2563eb" />
+        {/* כיסא נבחר */}
+        <rect x="40" y="40" width="20" height="20" rx="4" fill="#22c55e" />
+        <rect x="70" y="40" width="20" height="20" rx="4" fill="#2563eb" />
+
+        <rect x="10" y="70" width="20" height="20" rx="4" fill="#2563eb" />
+        <rect x="40" y="70" width="20" height="20" rx="4" fill="#2563eb" />
+        <rect x="70" y="70" width="20" height="20" rx="4" fill="#2563eb" />
+      </svg>
+      <span className="text-2xl font-bold text-gray-800">
+        SeatMap Manager
+      </span>
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add reusable SeatMap Manager logo component
- use logo component in navbar and home page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: eslint: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0186bda5883238466cc84fa0a3a12