### PR TITLE
Add demo email signup with auto account creation

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "pg": "^8.11.3",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-router-dom": "^7.8.1"
+    "react-router-dom": "^7.8.1",
+    "nodemailer": "^6.9.11"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/server/db.js
+++ b/server/db.js
@@ -11,6 +11,12 @@ export async function init() {
       data jsonb
     )
   `);
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS users (
+      email text PRIMARY KEY,
+      password text NOT NULL
+    )
+  `);
 }
 
 export function query(text, params) {

--- a/server/index.js
+++ b/server/index.js
@@ -1,10 +1,45 @@
 import express from 'express';
+import crypto from 'crypto';
+import nodemailer from 'nodemailer';
 import { init, query } from './db.js';
 
 const app = express();
 app.use(express.json());
 
 await init();
+
+app.post('/api/register', async (req, res) => {
+  const { email } = req.body;
+  if (!email) {
+    return res.status(400).json({ error: 'Email required' });
+  }
+  const password = crypto.randomBytes(8).toString('hex');
+  try {
+    await query(
+      'INSERT INTO users(email, password) VALUES ($1, $2) ON CONFLICT (email) DO UPDATE SET password = $2',
+      [email, password]
+    );
+    const transporter = nodemailer.createTransport({
+      host: process.env.SMTP_HOST,
+      port: parseInt(process.env.SMTP_PORT || '587', 10),
+      secure: false,
+      auth: {
+        user: process.env.SMTP_USER,
+        pass: process.env.SMTP_PASS
+      }
+    });
+    await transporter.sendMail({
+      from: process.env.SMTP_USER,
+      to: email,
+      subject: 'SeatFlow account details',
+      text: `Your password is: ${password}`
+    });
+    res.sendStatus(204);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
 
 app.get('/api/storage/:key', async (req, res) => {
   const { key } = req.params;

--- a/src/components/Home/Home.tsx
+++ b/src/components/Home/Home.tsx
@@ -1,7 +1,8 @@
-import React from "react";
+import React, { useState } from "react";
 import { Link } from "react-router-dom";
 import { Armchair, ArrowRight, Users, Zap, Sparkles } from "lucide-react";
 import Logo from "../common/Logo";
+import DemoRequestModal from "../common/DemoRequestModal";
 
 const Home: React.FC = () => {
   const features = [
@@ -39,6 +40,8 @@ const Home: React.FC = () => {
         "שינויים ועריכות מתבצעים בקלות ובמהירות, כך שתמיד תישארו עדכניים.",
     },
   ];
+
+  const [showDemo, setShowDemo] = useState(false);
 
   return (
     <div
@@ -80,12 +83,12 @@ const Home: React.FC = () => {
             >
               התחבר למערכת <ArrowRight className="h-5 w-5" />
             </Link>
-            <Link
-              to="/view/example"
+            <button
+              onClick={() => setShowDemo(true)}
               className="inline-flex items-center gap-2 px-7 py-3 rounded-xl border border-blue-600 bg-white text-blue-600 text-lg font-semibold hover:bg-blue-50 transition"
             >
               נסה דוגמה <Sparkles className="h-5 w-5" />
-            </Link>
+            </button>
             <Link
               to="/pricing"
               className="inline-flex items-center gap-2 px-7 py-3 rounded-xl border border-blue-600 bg-white text-blue-600 text-lg font-semibold hover:bg-blue-50 transition"
@@ -150,6 +153,7 @@ const Home: React.FC = () => {
           </div>
         </section>
       </div>
+      <DemoRequestModal isOpen={showDemo} onClose={() => setShowDemo(false)} />
     </div>
   );
 };

--- a/src/components/Pricing/Pricing.tsx
+++ b/src/components/Pricing/Pricing.tsx
@@ -1,5 +1,6 @@
-import React from "react";
+import React, { useState } from "react";
 import { Check, Sparkles, ArrowLeft, Shield } from "lucide-react";
+import DemoRequestModal from "../common/DemoRequestModal";
 
 /**
  * PricingSinglePlanWithDemo
@@ -7,6 +8,7 @@ import { Check, Sparkles, ArrowLeft, Shield } from "lucide-react";
  * TailwindCSS, RTL-friendly
  */
 export default function PricingSinglePlanWithDemo() {
+  const [showDemo, setShowDemo] = useState(false);
   const features: string[] = [
     "עיצוב מפת בית הכנסת",
     "מדבקות למקומות",
@@ -105,13 +107,13 @@ export default function PricingSinglePlanWithDemo() {
               </div>
 
               <div className="mt-6">
-                <a
-                  href="#demo" // TODO: wire to your demo route
+                <button
+                  onClick={() => setShowDemo(true)}
                   className="group inline-flex w-full items-center justify-center gap-2 rounded-xl border border-gray-300 bg-white px-5 py-3 text-sm font-semibold text-gray-900 transition hover:border-gray-400 hover:bg-gray-50"
                 >
                   נסו את הדמו
                   <ArrowLeft className="h-4 w-4 transition group-hover:-translate-x-0.5" />
-                </a>
+                </button>
                 <p className="mt-2 text-center text-xs text-gray-500">
                   הדמו אינו כולל שמירת נתונים קבועה.
                 </p>
@@ -187,6 +189,7 @@ export default function PricingSinglePlanWithDemo() {
           </div>
         </section>
       </div>
+      <DemoRequestModal isOpen={showDemo} onClose={() => setShowDemo(false)} />
     </div>
   );
 }

--- a/src/components/common/DemoRequestModal.tsx
+++ b/src/components/common/DemoRequestModal.tsx
@@ -1,0 +1,76 @@
+import React, { useState } from "react";
+
+interface DemoRequestModalProps {
+  isOpen: boolean;
+  onClose: () => void;
+}
+
+const DemoRequestModal: React.FC<DemoRequestModalProps> = ({ isOpen, onClose }) => {
+  const [email, setEmail] = useState("");
+  const [sent, setSent] = useState(false);
+
+  if (!isOpen) return null;
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    try {
+      await fetch("/api/register", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ email })
+      });
+      setSent(true);
+    } catch (err) {
+      console.error(err);
+    }
+  };
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50" dir="rtl">
+      <div className="rounded-xl bg-white p-6 shadow-lg w-full max-w-md">
+        {sent ? (
+          <div className="text-center space-y-4">
+            <p>סיסמה נשלחה למייל שלך.</p>
+            <button
+              onClick={onClose}
+              className="rounded-lg bg-blue-600 px-4 py-2 text-white"
+            >
+              סגור
+            </button>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="space-y-4">
+            <label className="block">
+              <span className="text-gray-700">כתובת מייל</span>
+              <input
+                type="email"
+                required
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+                className="mt-1 w-full rounded-md border px-3 py-2"
+              />
+            </label>
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={onClose}
+                className="rounded-lg border px-4 py-2"
+              >
+                ביטול
+              </button>
+              <button
+                type="submit"
+                className="rounded-lg bg-blue-600 px-4 py-2 text-white"
+              >
+                שלח
+              </button>
+            </div>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+};
+
+export default DemoRequestModal;
+


### PR DESCRIPTION
## Summary
- Gate demo access with new email signup modal used on home and pricing pages
- Auto-create user accounts via `/api/register` and send random password
- Introduce `users` table for storing account credentials

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b560c7a5d883238c5d5187965f1bee