### PR TITLE
feat: add profile fields and setup flow

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -14,7 +14,13 @@ export async function init() {
   await pool.query(`
     CREATE TABLE IF NOT EXISTS users (
       email text PRIMARY KEY,
-      password text NOT NULL
+      password text NOT NULL,
+      gabbai_name text,
+      phone text,
+      synagogue_name text,
+      address text,
+      city text,
+      contact_phone text
     )
   `);
 }

--- a/server/index.js
+++ b/server/index.js
@@ -41,6 +41,21 @@ app.post('/api/register', async (req, res) => {
   }
 });
 
+app.put('/api/users/:email', async (req, res) => {
+  const { email } = req.params;
+  const { gabbaiName, phone, synagogueName, address, city, contactPhone } = req.body;
+  try {
+    await query(
+      `UPDATE users SET gabbai_name = $1, phone = $2, synagogue_name = $3, address = $4, city = $5, contact_phone = $6 WHERE email = $7`,
+      [gabbaiName, phone, synagogueName, address, city, contactPhone, email]
+    );
+    res.sendStatus(204);
+  } catch (err) {
+    console.error(err);
+    res.status(500).json({ error: 'DB error' });
+  }
+});
+
 app.get('/api/storage/:key', async (req, res) => {
   const { key } = req.params;
   try {

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,6 +10,7 @@ import About from './components/About/About';
 import MapManagementGuide from './components/Seats/MapManagementGuide';
 import Login from './components/Auth/Login';
 import RequireAuth from './components/Auth/RequireAuth';
+import ProfileSetup from './components/Auth/ProfileSetup';
 import MapView from './components/Seats/MapView';
 import Pricing from './components/Pricing/Pricing';
 import Home from './components/Home/Home';
@@ -22,6 +23,7 @@ function App() {
           <Route path="/" element={<Home />} />
           <Route path="/login" element={<Login />} />
           <Route path="/pricing" element={<Pricing />} />
+          <Route path="/setup" element={<RequireAuth><ProfileSetup /></RequireAuth>} />
           <Route
             path="/view/:id"
             element={

--- a/src/components/Auth/ProfileSetup.tsx
+++ b/src/components/Auth/ProfileSetup.tsx
@@ -1,0 +1,102 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../../context/AuthContext';
+
+const ProfileSetup: React.FC = () => {
+  const { user, updateUser } = useAuth();
+  const navigate = useNavigate();
+
+  const [gabbaiName, setGabbaiName] = useState(user?.gabbaiName || '');
+  const [phone, setPhone] = useState(user?.phone || '');
+  const [synagogueName, setSynagogueName] = useState(user?.synagogueName || '');
+  const [address, setAddress] = useState(user?.address || '');
+  const [city, setCity] = useState(user?.city || '');
+  const [contactPhone, setContactPhone] = useState(user?.contactPhone || '');
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    updateUser({
+      gabbaiName,
+      phone,
+      synagogueName,
+      address,
+      city,
+      contactPhone,
+    });
+    if (user) {
+      try {
+        await fetch(`/api/users/${encodeURIComponent(user.email)}`, {
+          method: 'PUT',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ gabbaiName, phone, synagogueName, address, city, contactPhone }),
+        });
+      } catch (err) {
+        // ignore errors for now
+      }
+    }
+    navigate('/app');
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50" dir="rtl">
+      <form onSubmit={handleSubmit} className="bg-white p-8 rounded shadow-md w-full max-w-md space-y-4">
+        <h2 className="text-xl font-bold text-center">פרטי בית הכנסת</h2>
+        <input
+          type="text"
+          placeholder="שם הגבאי"
+          value={gabbaiName}
+          onChange={(e) => setGabbaiName(e.target.value)}
+          className="w-full p-2 border rounded"
+        />
+        <input
+          type="text"
+          placeholder="טלפון"
+          value={phone}
+          onChange={(e) => setPhone(e.target.value)}
+          className="w-full p-2 border rounded"
+        />
+        <input
+          type="text"
+          placeholder="שם בית הכנסת"
+          value={synagogueName}
+          onChange={(e) => setSynagogueName(e.target.value)}
+          className="w-full p-2 border rounded"
+          required
+        />
+        <input
+          type="text"
+          placeholder="כתובת"
+          value={address}
+          onChange={(e) => setAddress(e.target.value)}
+          className="w-full p-2 border rounded"
+          required
+        />
+        <input
+          type="text"
+          placeholder="עיר"
+          value={city}
+          onChange={(e) => setCity(e.target.value)}
+          className="w-full p-2 border rounded"
+        />
+        <input
+          type="text"
+          placeholder="טלפון ליצירת קשר"
+          value={contactPhone}
+          onChange={(e) => setContactPhone(e.target.value)}
+          className="w-full p-2 border rounded"
+        />
+        <input
+          type="email"
+          value={user?.email || ''}
+          className="w-full p-2 border rounded bg-gray-100"
+          disabled
+        />
+        <button type="submit" className="w-full bg-blue-600 text-white py-2 rounded">
+          שמור
+        </button>
+      </form>
+    </div>
+  );
+};
+
+export default ProfileSetup;

--- a/src/components/Auth/RequireAuth.tsx
+++ b/src/components/Auth/RequireAuth.tsx
@@ -10,6 +10,10 @@ const RequireAuth: React.FC<{ children: JSX.Element }> = ({ children }) => {
     return <Navigate to="/login" state={{ from: location }} replace />;
   }
 
+  if ((!user.synagogueName || !user.address) && location.pathname !== '/setup') {
+    return <Navigate to="/setup" replace />;
+  }
+
   return children;
 };
 

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -4,12 +4,20 @@ import { useLocalStorage } from '../hooks/useLocalStorage';
 interface User {
   username: string;
   password: string;
+  gabbaiName?: string;
+  phone?: string;
+  synagogueName?: string;
+  address?: string;
+  city?: string;
+  contactPhone?: string;
+  email: string;
 }
 
 interface AuthContextType {
   user: User | null;
   login: (username: string, password: string) => void;
   register: (username: string, password: string) => void;
+  updateUser: (data: Partial<User>) => void;
   logout: () => void;
 }
 
@@ -39,14 +47,21 @@ export const AuthProvider: React.FC<{ children: ReactNode }> = ({ children }) =>
     if (users.find(u => u.username === username)) {
       throw new Error('שם משתמש כבר קיים');
     }
-    const newUser = { username, password };
+    const newUser: User = { username, password, email: username };
     setUsers([...users, newUser]);
+  };
+
+  const updateUser = (data: Partial<User>) => {
+    if (!user) return;
+    const updated = { ...user, ...data } as User;
+    setUser(updated);
+    setUsers(users.map(u => (u.username === user.username ? updated : u)));
   };
 
   const logout = () => setUser(null);
 
   return (
-    <AuthContext.Provider value={{ user, login, register, logout }}>
+    <AuthContext.Provider value={{ user, login, register, updateUser, logout }}>
       {children}
     </AuthContext.Provider>
   );


### PR DESCRIPTION
## Summary
- extend user model and auth context with optional profile details
- add first-login profile setup form requiring synagogue name and address
- expand server schema and add endpoint for updating user profile data

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden fetching packages)*

------
https://chatgpt.com/codex/tasks/task_e_68b5656867688323b9bfd112df9e21bc