### PR TITLE
Style registration email and add login header

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -40,8 +40,17 @@ app.post('/api/register', async (req, res) => {
     await transporter.sendMail({
       from: process.env.SMTP_USER,
       to: email,
-      subject: 'SeatFlow account details',
-      text: `Your password is: ${password}`
+      subject: 'SeatFlow - פרטי התחברות',
+      text: `סיסמתך היא: ${password}. להתחברות: https://seatflow.tech/login`,
+      html: `
+        <div style="font-family:Arial,sans-serif;line-height:1.6;direction:rtl;text-align:right;">
+          <h1 style="color:#1e40af;">ברוך הבא ל-SeatFlow</h1>
+          <p>היי, תודה שנרשמת למערכת שלנו. להלן סיסמתך:</p>
+          <p style="font-size:24px;font-weight:bold;color:#1e3a8a;">${password}</p>
+          <p>כדי להתחבר למערכת לחץ על הקישור הבא:</p>
+          <a href="https://seatflow.tech/login" style="display:inline-block;padding:10px 20px;background-color:#1e40af;color:#ffffff;text-decoration:none;border-radius:8px;">התחברות למערכת</a>
+        </div>
+      `
     });
 
     res.sendStatus(204);

--- a/src/components/About/About.tsx
+++ b/src/components/About/About.tsx
@@ -1,14 +1,15 @@
 import React from 'react';
-import { 
-  Armchair, 
-  Users, 
-  Zap, 
-  Shield, 
-  Heart, 
+import {
+  Armchair,
+  Users,
+  Zap,
+  Shield,
+  Heart,
   Target,
   CheckCircle,
   Star
 } from 'lucide-react';
+import Header from '../common/Header';
 
 const About: React.FC = () => {
   const features = [
@@ -45,6 +46,7 @@ const About: React.FC = () => {
 
   return (
     <div className="space-y-12">
+      <Header />
       {/* Header */}
       <div className="text-center">
         <div className="flex items-center justify-center mb-6">

--- a/src/components/Contact/Contact.tsx
+++ b/src/components/Contact/Contact.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useRef } from 'react';
 import { Mail, Phone, MapPin, Send, CheckCircle, User, MessageSquare, Map, X, ArrowLeft, ArrowRight, ArrowUp, ArrowDown } from 'lucide-react';
 import Align from '../common/Align';
 import { ContactForm } from '../../types';
+import Header from '../common/Header';
 
 // Dimensions for the map modal. Using fixed values keeps the map inside
 // a constant frame regardless of the viewport size.
@@ -77,6 +78,7 @@ const Contact: React.FC = () => {
 
   return (
     <div className="space-y-8">
+      <Header />
       <Align align="center">
         <h1 className="text-4xl font-bold text-gray-900 mb-4">צור קשר</h1>
         <p className="text-xl text-gray-600 max-w-2xl mx-auto">

--- a/src/components/Home/Home.tsx
+++ b/src/components/Home/Home.tsx
@@ -2,6 +2,7 @@ import React, { useState } from "react";
 import { Link } from "react-router-dom";
 import { Armchair, ArrowRight, Users, Zap, Sparkles } from "lucide-react";
 import Logo from "../common/Logo";
+import Header from "../common/Header";
 import DemoRequestModal from "../common/DemoRequestModal";
 
 const Home: React.FC = () => {
@@ -45,10 +46,11 @@ const Home: React.FC = () => {
 
   return (
     <div
-      className="min-h-screen bg-gradient-to-b from-blue-50 via-indigo-50 to-white pt-12 pb-20"
+      className="min-h-screen bg-gradient-to-b from-blue-50 via-indigo-50 to-white pb-20"
       dir="rtl"
     >
-      <div className="max-w-7xl mx-auto px-4 space-y-24">
+      <Header />
+      <div className="max-w-7xl mx-auto px-4 space-y-24 pt-12">
         {/* Hero */}
         <section className="text-center space-y-8">
           <div className="flex justify-center drop-shadow-md animate-bounce">

--- a/src/components/Pricing/Pricing.tsx
+++ b/src/components/Pricing/Pricing.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import { Check, Sparkles, ArrowLeft, Shield } from "lucide-react";
 import DemoRequestModal from "../common/DemoRequestModal";
+import Header from "../common/Header";
 
 /**
  * PricingSinglePlanWithDemo
@@ -20,6 +21,7 @@ export default function PricingSinglePlanWithDemo() {
 
   return (
     <div className="relative isolate overflow-hidden" dir="rtl">
+      <Header />
       {/* Soft background */}
       <div className="pointer-events-none absolute inset-0 -z-10">
         <div className="absolute -top-24 left-1/2 h-72 w-[110%] -translate-x-1/2 rounded-[100%] bg-gradient-to-b from-blue-50 to-transparent blur-2xl" />

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+import Logo from './Logo';
+
+const Header: React.FC = () => (
+  <header className="bg-white shadow-sm border-b">
+    <div className="container mx-auto px-4 py-4 flex justify-between items-center">
+      <Logo />
+      <Link
+        to="/login"
+        className="px-4 py-2 rounded-lg bg-blue-600 text-white font-semibold hover:bg-blue-700 transition"
+      >
+        התחברות
+      </Link>
+    </div>
+  </header>
+);
+
+export default Header;


### PR DESCRIPTION
## Summary
- style registration email with modern HTML, prominent password and link to https://seatflow.tech/login
- add reusable header component with login button and use it on marketing pages

## Testing
- ⚠️ `npm test` (no test script)
- ⚠️ `npm run lint` (missing @eslint/js dependency)
- ⚠️ `npm run build` (vite not installed)


------
https://chatgpt.com/codex/tasks/task_e_68b56b7b89f083238e50c65ad9711866