### PR TITLE
feat: log SMTP acceptance and rejection

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -63,7 +63,15 @@ app.post('/api/register', async (req, res) => {
         }
       ]
     });
-    console.log('Email sent', info.messageId);
+    if (info.rejected?.length) {
+      console.error('Email rejected by server', info.rejected);
+      throw new Error('Email was rejected by SMTP server');
+    }
+    if (!info.accepted?.length) {
+      console.error('No recipients accepted the email');
+      throw new Error('Email was not accepted by any recipients');
+    }
+    console.log('Email sent', info.messageId, 'accepted:', info.accepted);
 
     res.sendStatus(204);
   } catch (err) {


### PR DESCRIPTION
## Summary
- log SMTP server acceptance and rejections when sending registration emails to aid debugging

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/express)


------
https://chatgpt.com/codex/tasks/task_e_68b5f9dfbc7883238863958d29d87dd0