### PR TITLE
chore: route API requests to SeatFlow production domain

### DIFF
--- a/src/api.ts
+++ b/src/api.ts
@@ -1,0 +1,1 @@
+export const API_BASE_URL = 'https://api.seatflow.tech';

--- a/src/components/Auth/ProfileSetup.tsx
+++ b/src/components/Auth/ProfileSetup.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../context/AuthContext';
+import { API_BASE_URL } from '../../api';
 
 const ProfileSetup: React.FC = () => {
   const { user, updateUser } = useAuth();
@@ -25,7 +26,7 @@ const ProfileSetup: React.FC = () => {
     });
     if (user) {
       try {
-        await fetch(`/api/users/${encodeURIComponent(user.email)}`, {
+        await fetch(`${API_BASE_URL}/api/users/${encodeURIComponent(user.email)}`, {
           method: 'PUT',
           headers: { 'Content-Type': 'application/json' },
           body: JSON.stringify({ gabbaiName, phone, synagogueName, address, city, contactPhone }),

--- a/src/components/Pricing/ProPayment.tsx
+++ b/src/components/Pricing/ProPayment.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { API_BASE_URL } from "../../api";
 
 export default function ProPayment() {
   const [form, setForm] = useState({
@@ -17,7 +18,7 @@ export default function ProPayment() {
     e.preventDefault();
     setStatus("processing");
     try {
-      const res = await fetch("/api/zcredit/charge", {
+      const res = await fetch(`${API_BASE_URL}/api/zcredit/charge`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({

--- a/src/components/common/DemoRequestModal.tsx
+++ b/src/components/common/DemoRequestModal.tsx
@@ -1,4 +1,5 @@
 import React, { useState } from "react";
+import { API_BASE_URL } from "../../api";
 
 interface DemoRequestModalProps {
   isOpen: boolean;
@@ -15,7 +16,7 @@ const DemoRequestModal: React.FC<DemoRequestModalProps> = ({ isOpen, onClose }) 
     e.preventDefault();
     console.log("Submitting registration request", { email });
     try {
-      const res = await fetch("/api/register", {
+      const res = await fetch(`${API_BASE_URL}/api/register`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({ email })

--- a/src/hooks/useServerStorage.ts
+++ b/src/hooks/useServerStorage.ts
@@ -1,4 +1,5 @@
 import { useState, useEffect, useRef } from 'react';
+import { API_BASE_URL } from '../api';
 
 export function useServerStorage<T>(
   key: string,
@@ -16,7 +17,7 @@ export function useServerStorage<T>(
   useEffect(() => {
     const fetchValue = async () => {
       try {
-        const res = await fetch(`http://localhost:3001/api/storage/${storageKey}`);
+        const res = await fetch(`${API_BASE_URL}/api/storage/${storageKey}`);
         if (res.ok) {
           const data = await res.json();
           if (data !== null) {
@@ -33,7 +34,7 @@ export function useServerStorage<T>(
   const setValue = (value: T | ((val: T) => T)) => {
     const valueToStore = value instanceof Function ? value(storedValue) : value;
     setStoredValue(valueToStore);
-    fetch(`http://localhost:3001/api/storage/${storageKey}`, {
+    fetch(`${API_BASE_URL}/api/storage/${storageKey}`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify(valueToStore),


### PR DESCRIPTION
## Summary
- centralize API base URL in `API_BASE_URL`
- send client requests to `https://api.seatflow.tech`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68b6a611c5988323a04863b98b77f82d