### PR TITLE
fix: allow cross-origin requests

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "server": "node server/index.js"
   },
   "dependencies": {
+    "cors": "^2.8.5",
     "express": "^4.19.2",
     "html2canvas": "^1.4.1",
     "jspdf": "^2.5.1",

--- a/server/index.js
+++ b/server/index.js
@@ -1,5 +1,6 @@
 import 'dotenv/config';
 import express from 'express';
+import cors from 'cors';
 import crypto from 'crypto';
 import nodemailer from 'nodemailer';
 import { init, query } from './db.js';
@@ -7,6 +8,7 @@ import { init, query } from './db.js';
 const logoPath = new URL('https://seatflow.tech/logo.svg', import.meta.url).pathname;
 
 const app = express();
+app.use(cors({ origin: 'https://seatflow.tech' }));
 app.use(express.json());
 
 const transporter = nodemailer.createTransport({


### PR DESCRIPTION
## Summary
- add CORS middleware allowing requests from seatflow.tech
- add cors dependency

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68b6a929d6408323ab1447599836d340