### PR TITLE
Use ZCredit WebCheckout for payments

### DIFF
--- a/.env.e
+++ b/.env.e
@@ -9,3 +9,10 @@ MAIL_PORT=587
 MAIL_USERNAME=your-mail-username
 MAIL_PASSWORD=your-mail-password
 MAIL_FROM="ניהול מושבים חכם<no-reply@seatflow.tech>"
+
+# ZCredit WebCheckout
+ZCREDIT_BASE_URL=https://pci.zcredit.co.il/zCreditWS/
+ZCREDIT_TERMINAL=1234567
+ZCREDIT_PASSWORD=YOUR_TERMINAL_PASSWORD
+ZCREDIT_KEY=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
+PUBLIC_BASE_URL=https://yourdomain.com

--- a/README.md
+++ b/README.md
@@ -18,12 +18,19 @@ The server creates a `storage` table if it does not exist and listens on `http:/
 
 ### ZCredit payments
 
-To accept Pro plan payments via ZCredit, set the following environment variables before running the server:
+To accept Pro plan payments via ZCredit WebCheckout, set the following environment variables before running the server:
 
 ```
+ZCREDIT_BASE_URL=https://pci.zcredit.co.il/zCreditWS/
 ZCREDIT_TERMINAL=<terminal number>
-ZCREDIT_USER=<api username>
-ZCREDIT_PASS=<api password>
+ZCREDIT_PASSWORD=<terminal password>
+ZCREDIT_KEY=<guid key>
+PUBLIC_BASE_URL=https://yourdomain.com
 ```
 
-The server exposes `POST /api/zcredit/charge` which forwards card details to ZCredit's API (`https://api.zcredit.co.il/api/v3/transactions/charge`). Adjust the endpoint and fields as required by your account.
+The server exposes two endpoints:
+
+- `POST /api/zcredit/create-checkout` – creates a WebCheckout session and returns a URL to redirect the customer.
+- `POST /api/zcredit/callback` – receives the server-to-server notification from ZCredit after payment.
+
+Adjust endpoint URLs and payload fields according to your ZCredit documentation.

--- a/package.json
+++ b/package.json
@@ -11,6 +11,8 @@
     "server": "node server/index.js"
   },
   "dependencies": {
+    "axios": "^1.6.8",
+    "body-parser": "^1.20.2",
     "express": "^4.19.2",
     "html2canvas": "^1.4.1",
     "jspdf": "^2.5.1",

--- a/server/index.js
+++ b/server/index.js
@@ -1,5 +1,7 @@
 import 'dotenv/config';
 import express from 'express';
+import axios from 'axios';
+import bodyParser from 'body-parser';
 import crypto from 'crypto';
 import nodemailer from 'nodemailer';
 import { init, query } from './db.js';
@@ -7,7 +9,16 @@ import { init, query } from './db.js';
 const logoPath = new URL('https://seatflow.tech/logo.svg', import.meta.url).pathname;
 
 const app = express();
-app.use(express.json());
+app.use(bodyParser.json());
+app.use(bodyParser.urlencoded({ extended: true }));
+
+const {
+  ZCREDIT_BASE_URL,
+  ZCREDIT_TERMINAL,
+  ZCREDIT_PASSWORD,
+  ZCREDIT_KEY,
+  PUBLIC_BASE_URL
+} = process.env;
 
 const transporter = nodemailer.createTransport({
   host: process.env.SMTP_HOST,
@@ -122,34 +133,91 @@ app.post('/api/storage/:key', async (req, res) => {
   }
 });
 
-app.post('/api/zcredit/charge', async (req, res) => {
-  const { amount, cardNumber, expMonth, expYear, cvv } = req.body || {};
+app.post('/api/zcredit/create-checkout', async (req, res) => {
   try {
-    const response = await fetch('https://api.zcredit.co.il/api/v3/transactions/charge', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({
-        terminalNumber: process.env.ZCREDIT_TERMINAL,
-        userName: process.env.ZCREDIT_USER,
-        password: process.env.ZCREDIT_PASS,
-        sum: amount,
-        card: {
-          number: cardNumber,
-          expMonth,
-          expYear,
-          cvv
-        }
-      })
+    const { amount, description, customerName, customerEmail, orderId } = req.body;
+    const endpoint = `${ZCREDIT_BASE_URL}PaymentGateway.asmx/CreateWebCheckoutSession`;
+
+    const successUrl = `${PUBLIC_BASE_URL}/thank-you?orderId=${encodeURIComponent(orderId || '')}`;
+    const cancelUrl = `${PUBLIC_BASE_URL}/payment-cancelled?orderId=${encodeURIComponent(orderId || '')}`;
+    const callbackUrl = `${PUBLIC_BASE_URL}/api/zcredit/callback`;
+
+    const payload = {
+      TerminalNumber: ZCREDIT_TERMINAL,
+      TerminalPassword: ZCREDIT_PASSWORD,
+      ZCreditKey: ZCREDIT_KEY,
+      TransactionSum: Number(amount),
+      Payments: 1,
+      CurrencyCode: 1,
+      TransactionType: 1,
+      CustomerName: customerName || '',
+      CustomerEmail: customerEmail || '',
+      Description: description || `Order ${orderId || ''}`,
+      SuccessRedirectUrl: successUrl,
+      CancelRedirectUrl: cancelUrl,
+      CallbackUrl: callbackUrl,
+      ExternalOrderId: orderId || ''
+    };
+
+    const response = await axios.post(endpoint, payload, {
+      headers: { 'Content-Type': 'application/json' }
     });
-    const data = await response.json();
-    if (!response.ok) {
-      console.error('ZCredit error:', data);
-      return res.status(500).json({ error: 'Payment failed', details: data });
+
+    const checkoutUrl =
+      response.data?.WebCheckoutUrl ||
+      response.data?.CheckoutPage ||
+      response.data?.Url;
+
+    if (!checkoutUrl) {
+      return res.status(500).json({
+        ok: false,
+        message: 'לא התקבל קישור תשלום מה־API',
+        raw: response.data
+      });
     }
-    res.json(data);
+
+    return res.json({ ok: true, checkoutUrl, raw: response.data });
   } catch (err) {
-    console.error('zcredit charge error:', err);
-    res.status(500).json({ error: 'Server error' });
+    return res.status(500).json({
+      ok: false,
+      message: 'שגיאה ביצירת קישור תשלום',
+      error: err.response?.data || err.message
+    });
+  }
+});
+
+app.post('/api/zcredit/callback', async (req, res) => {
+  try {
+    console.log('ZCredit Callback body:', req.body);
+
+    const signatureFromZC = req.body.Signature;
+    const dataToSign = req.body.DataToSign;
+
+    if (signatureFromZC && dataToSign) {
+      const hmac = crypto
+        .createHmac('sha256', ZCREDIT_KEY)
+        .update(dataToSign, 'utf8')
+        .digest('hex');
+
+      const valid = hmac.toLowerCase() === String(signatureFromZC).toLowerCase();
+      if (!valid) {
+        console.warn('אזהרה: חתימה לא תואמת!');
+      }
+    } else {
+      console.warn('אזהרה: לא נמצאו שדות חתימה – עדכן לפי התיעוד שלך.');
+    }
+
+    const status = req.body.Status || req.body.status || '';
+    const transactionId = req.body.TransactionId || req.body.transactionId || '';
+    const authNumber = req.body.AuthNumber || req.body.authNumber || '';
+    const orderId = req.body.ExternalOrderId || req.body.orderId || '';
+
+    console.log('Parsed:', { status, transactionId, authNumber, orderId });
+
+    return res.status(200).send('OK');
+  } catch (err) {
+    console.error('Callback error:', err);
+    return res.status(500).send('Server error');
   }
 });
 

--- a/src/components/Pricing/ProPayment.tsx
+++ b/src/components/Pricing/ProPayment.tsx
@@ -2,34 +2,26 @@ import React, { useState } from "react";
 import { API_BASE_URL } from "../../api";
 
 export default function ProPayment() {
-  const [form, setForm] = useState({
-    cardNumber: "",
-    expMonth: "",
-    expYear: "",
-    cvv: "",
-  });
-  const [status, setStatus] = useState<"idle" | "processing" | "success" | "error">("idle");
+  const [status, setStatus] = useState<"idle" | "processing" | "error">("idle");
 
-  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setForm({ ...form, [e.target.name]: e.target.value });
-  };
-
-  const handleSubmit = async (e: React.FormEvent) => {
-    e.preventDefault();
+  const handlePay = async () => {
     setStatus("processing");
     try {
-      const res = await fetch(`${API_BASE_URL}/api/zcredit/charge`, {
+      const res = await fetch(`${API_BASE_URL}/api/zcredit/create-checkout`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
           amount: 1099,
-          cardNumber: form.cardNumber,
-          expMonth: form.expMonth,
-          expYear: form.expYear,
-          cvv: form.cvv,
-        }),
+          description: "תשלום עבור פרו",
+          orderId: "pro-plan"
+        })
       });
-      setStatus(res.ok ? "success" : "error");
+      const data = await res.json();
+      if (data.ok && data.checkoutUrl) {
+        window.location.href = data.checkoutUrl;
+      } else {
+        setStatus("error");
+      }
     } catch (err) {
       console.error("payment error", err);
       setStatus("error");
@@ -39,55 +31,17 @@ export default function ProPayment() {
   return (
     <div className="mx-auto max-w-md p-4" dir="rtl">
       <h1 className="mb-4 text-center text-2xl font-bold">תשלום עבור פרו</h1>
-      <form onSubmit={handleSubmit} className="space-y-4">
-        <input
-          name="cardNumber"
-          value={form.cardNumber}
-          onChange={handleChange}
-          placeholder="מספר כרטיס"
-          className="w-full rounded border px-3 py-2"
-          required
-        />
-        <div className="flex space-x-2 rtl:space-x-reverse">
-          <input
-            name="expMonth"
-            value={form.expMonth}
-            onChange={handleChange}
-            placeholder="חודש"
-            className="w-full rounded border px-3 py-2"
-            required
-          />
-          <input
-            name="expYear"
-            value={form.expYear}
-            onChange={handleChange}
-            placeholder="שנה"
-            className="w-full rounded border px-3 py-2"
-            required
-          />
-        </div>
-        <input
-          name="cvv"
-          value={form.cvv}
-          onChange={handleChange}
-          placeholder="CVV"
-          className="w-full rounded border px-3 py-2"
-          required
-        />
-        <button
-          type="submit"
-          disabled={status === "processing"}
-          className="w-full rounded bg-blue-600 px-4 py-2 font-semibold text-white hover:bg-blue-700"
-        >
-          {status === "processing" ? "מעבד..." : "שלם עכשיו"}
-        </button>
-      </form>
-      {status === "success" && (
-        <p className="mt-4 text-center text-green-600">התשלום הצליח!</p>
-      )}
+      <button
+        onClick={handlePay}
+        disabled={status === "processing"}
+        className="w-full rounded bg-blue-600 px-4 py-2 font-semibold text-white hover:bg-blue-700"
+      >
+        {status === "processing" ? "מעבד..." : "שלם עכשיו"}
+      </button>
       {status === "error" && (
         <p className="mt-4 text-center text-red-600">אירעה שגיאה בתשלום.</p>
       )}
     </div>
   );
 }
+


### PR DESCRIPTION
## Summary
- add axios and body-parser dependencies
- replace direct card charge with WebCheckout session creation and callback handling
- simplify ProPayment component to redirect to ZCredit checkout
- document new ZCredit environment variables and endpoints

## Testing
- `npm install` *(fails: 403 Forbidden from registry)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b6a9f7672c8323b71c1568dbef4e80