### PR TITLE
feat: add CORS allowed origins

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -29,7 +29,26 @@ const SMTP_USER = must('SMTP_USER');
 const SMTP_PASS = must('SMTP_PASS');
 
 // --- CORS ---
-app.use(cors({ origin: PUBLIC_BASE_URL }));
+const allowedOrigins = ['https://seatflow.tech', 'https://www.seatflow.tech'];
+
+app.use(cors({
+  origin(origin, cb) {
+    if (!origin || allowedOrigins.includes(origin)) return cb(null, true);
+    return cb(new Error('Not allowed by CORS'));
+  },
+  credentials: true,
+  methods: ['GET', 'POST', 'PUT', 'PATCH', 'DELETE', 'OPTIONS'],
+  allowedHeaders: ['Content-Type', 'Authorization'],
+  maxAge: 86400
+}));
+
+app.options('*', cors({
+  origin(origin, cb) {
+    if (!origin || allowedOrigins.includes(origin)) return cb(null, true);
+    return cb(new Error('Not allowed by CORS'));
+  },
+  credentials: true
+}));
 
 // --- Body parsers ---
 // Z-Credit עלול לשלוח callback כ-JSON או כ-form-urlencoded


### PR DESCRIPTION
## Summary
- add CORS configuration allowing only seatflow.tech domains

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/axios)*

------
https://chatgpt.com/codex/tasks/task_e_68b6b84a0d0c83239d8c2ad5c4057e1d