### PR TITLE
Simplify ZCredit checkout session creation

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,9 +21,8 @@ The server creates a `storage` table if it does not exist and listens on `http:/
 To accept Pro plan payments via ZCredit WebCheckout, set the following environment variables before running the server:
 
 ```
-ZCREDIT_BASE_URL=https://pci.zcredit.co.il/zCreditWS/
-ZCREDIT_TERMINAL=<terminal number>
-ZCREDIT_PASSWORD=<terminal password>
+ZCREDIT_CREATE_SESSION_URL=https://pci.zcredit.co.il/WebCheckout/api/CreateSession
+ZCREDIT_WEBCHECKOUT_KEY=<webcheckout key>
 ZCREDIT_KEY=<guid key>
 PUBLIC_BASE_URL=https://yourdomain.com
 ```


### PR DESCRIPTION
## Summary
- simplify `/api/zcredit/create-checkout` logic to use `ZCREDIT_CREATE_SESSION_URL` and `ZCREDIT_WEBCHECKOUT_KEY`
- remove unused ZCredit terminal/password env vars
- document new environment variables

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js'; network install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68b74b1ab5788323a0d3342b6607c02a