### PR TITLE
Handle nested SessionUrl in ZCredit response

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -215,7 +215,11 @@ app.post('/api/zcredit/create-checkout', async (req, res) => {
     }
 
     const data = response.data || {};
-    const sessionUrl = data.SessionUrl || data.sessionUrl || data.Url || data.WebCheckoutUrl;
+    const sessionUrl =
+      data?.Data?.SessionUrl ||
+      data?.SessionUrl ||
+      data?.Url ||
+      data?.WebCheckoutUrl;
 
     if (!sessionUrl) {
       const raw = typeof data === 'string' ? data.slice(0, 800) : JSON.stringify(data).slice(0, 800);


### PR DESCRIPTION
## Summary
- Look for `SessionUrl` inside `data.Data` before falling back to other fields

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_68b74d170dac8323a1a17c92565a56e5