### PR TITLE
store credit charge details

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -40,9 +40,11 @@ export async function init() {
       transaction_date TIMESTAMP,
       transaction_id text,
       status text,
-      description text
+      description text,
+      details jsonb
     )
   `);
+  await pool.query(`ALTER TABLE credit_charges ADD COLUMN IF NOT EXISTS details jsonb`);
 }
 
 export function query(text, params) {

--- a/server/index.js
+++ b/server/index.js
@@ -305,9 +305,10 @@ app.post('/api/zcredit/callback', async (req, res) => {
         `UPDATE credit_charges
          SET status = $1,
              transaction_id = $2,
-             transaction_date = NOW()
-         WHERE order_id = $3`,
-        [status || '', transactionId || authNumber || '', orderId]
+             transaction_date = NOW(),
+             details = $3
+         WHERE order_id = $4`,
+        [status || '', transactionId || authNumber || '', body, orderId]
       );
     }
 


### PR DESCRIPTION
## Summary
- add `details` jsonb column to `credit_charges` table and ensure column exists
- capture entire ZCredit callback payload when updating charge records

## Testing
- ⚠️ `npm test` *(script not found)*
- ⚠️ `npm run lint` *(missing @eslint/js dependency)*
- ⚠️ `npm ci` *(npm registry returned 403)*

------
https://chatgpt.com/codex/tasks/task_e_68b7b16ff4448323ae8d8b0e806899d5