### PR TITLE
feat: store ZCredit callback data

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -45,6 +45,13 @@ export async function init() {
     )
   `);
   await pool.query(`ALTER TABLE credit_charges ADD COLUMN IF NOT EXISTS details jsonb`);
+  await pool.query(`
+    CREATE TABLE IF NOT EXISTS zcredit_callbacks (
+      id SERIAL PRIMARY KEY,
+      payload jsonb,
+      received_at TIMESTAMP DEFAULT NOW()
+    )
+  `);
 }
 
 export function query(text, params) {

--- a/server/index.js
+++ b/server/index.js
@@ -280,6 +280,13 @@ app.post('/api/zcredit/callback', async (req, res) => {
     const body = req.body || {};
     console.log('ZCredit Callback:', body);
 
+    // save raw callback payload
+    try {
+      await query(`INSERT INTO zcredit_callbacks(payload) VALUES ($1)`, [body]);
+    } catch (e) {
+      console.error('Failed to store callback payload', e);
+    }
+
     // אימות חתימה (דוגמה בלבד – עדכן לפי הדוק שלך)
     const signature = body.Signature || body.signature;
     const dataToSign = body.DataToSign || body.dataToSign;


### PR DESCRIPTION
## Summary
- log raw ZCredit callback payloads to the database
- add `zcredit_callbacks` table for auditing callback data

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b7b82e664883238bc68ab15cb6c702