### PR TITLE
feat: support SMTP secure option

### DIFF
--- a/ecosystem.config.js
+++ b/ecosystem.config.js
@@ -10,7 +10,8 @@ module.exports = {
       SMTP_PORT: "465",
       SMTP_USER: "info@seatflow.online",
       SMTP_PASS: "613Ml#613",
-      SMTP_FROM: "ניהול מושבים חכם<info@seatflow.online>"
+      SMTP_FROM: "ניהול מושבים חכם<info@seatflow.online>",
+      SMTP_SECURE: "true"
     }
   }]
 }

--- a/server/index.js
+++ b/server/index.js
@@ -24,6 +24,7 @@ const SMTP_HOST = must('SMTP_HOST');
 const SMTP_PORT = must('SMTP_PORT');
 const SMTP_USER = must('SMTP_USER');
 const SMTP_PASS = must('SMTP_PASS');
+const SMTP_SECURE = must('SMTP_SECURE') === 'true';
 
 // --- CORS ---
 const allowedOrigins = ['https://seatflow.tech', 'https://www.seatflow.tech'];
@@ -55,7 +56,7 @@ app.use(bodyParser.urlencoded({ extended: true }));
 const transporter = nodemailer.createTransport({
   host: SMTP_HOST,
   port: parseInt(SMTP_PORT, 10),
-  secure: false,
+  secure: SMTP_SECURE,
   auth: { user: SMTP_USER, pass: SMTP_PASS }
 });
 


### PR DESCRIPTION
## Summary
- add SMTP_SECURE env var to PM2 config
- configure Nodemailer secure mode via SMTP_SECURE

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/axios)*

------
https://chatgpt.com/codex/tasks/task_e_68b7bdeb279083238a8605e964591f67