### PR TITLE
fix: correct logo path for emails

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -7,7 +7,7 @@ import nodemailer from 'nodemailer';
 import { init, query } from './db.js';
 import cors from 'cors';
 
-const logoPath = new URL('https://seatflow.tech/logo.svg', import.meta.url).pathname;
+const logoPath = new URL('../public/logo.svg', import.meta.url).pathname;
 
 const app = express();
 


### PR DESCRIPTION
## Summary
- reference the bundled logo for registration and thank-you emails

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68b7c10e8c008323a5a78c4f19684374