### PR TITLE
Use database-backed login

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -124,6 +124,29 @@ app.post('/api/register', async (req, res) => {
   }
 });
 
+app.post('/api/login', async (req, res) => {
+  const { email, password } = req.body || {};
+  if (!email || !password) {
+    return res.status(400).json({ error: 'Email and password required' });
+  }
+
+  try {
+    const { rows } = await query(
+      `SELECT email, password, gabbai_name AS "gabbaiName", phone, synagogue_name AS "synagogueName", address, city, contact_phone AS "contactPhone" FROM users WHERE email=$1`,
+      [email]
+    );
+    const user = rows[0];
+    if (!user || user.password !== password) {
+      return res.status(401).json({ error: 'שם משתמש או סיסמה שגויים' });
+    }
+    delete user.password;
+    res.json({ user });
+  } catch (err) {
+    console.error('login error:', err);
+    res.status(500).json({ error: 'Server error' });
+  }
+});
+
 app.put('/api/users/:email', async (req, res) => {
   const { email } = req.params;
   const { gabbaiName, phone, synagogueName, address, city, contactPhone } = req.body || {};

--- a/src/components/Auth/Login.tsx
+++ b/src/components/Auth/Login.tsx
@@ -4,7 +4,7 @@ import { useAuth } from '../../context/AuthContext';
 import EmailRequestModal from './EmailRequestModal';
 
 const Login: React.FC = () => {
-  const [username, setUsername] = useState('');
+  const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
   const [showReset, setShowReset] = useState(false);
@@ -12,10 +12,10 @@ const Login: React.FC = () => {
   const navigate = useNavigate();
   const { login } = useAuth();
 
-  const handleSubmit = (e: React.FormEvent) => {
+  const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      login(username, password);
+      await login(email, password);
       navigate('/app');
     } catch (err) {
       setError((err as Error).message);
@@ -28,10 +28,10 @@ const Login: React.FC = () => {
         <h2 className="text-xl font-bold text-center">כניסה</h2>
         {error && <div className="text-red-500 text-sm text-center">{error}</div>}
         <input
-          type="text"
-          placeholder="שם משתמש"
-          value={username}
-          onChange={(e) => setUsername(e.target.value)}
+          type="email"
+          placeholder="מייל"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
           className="w-full p-2 border rounded"
           required
         />

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -200,7 +200,7 @@ const generateSeatsFromBenches = (benches: Bench[]): Seat[] => {
 
 export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
   const { user } = useAuth();
-  const userKey = user?.username ?? 'guest';
+  const userKey = user?.email ?? 'guest';
   const [worshipers, setWorshipers] = useLocalStorage<Worshiper[]>('worshipers', [
     {
       id: '1',


### PR DESCRIPTION
## Summary
- authenticate users against the PostgreSQL `users` table via a new `/api/login` endpoint
- update React AuthContext and login form to fetch credentials from the server instead of localStorage
- key app data by `user.email` rather than a local username

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68b811f48fe083238dfeec6e1c37e22b