### PR TITLE
Ensure server storage data is valid JSON

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -185,11 +185,18 @@ app.post('/api/storage/:key', async (req, res) => {
         return res.status(400).json({ error: 'Invalid JSON' });
       }
     }
+    let json;
+    try {
+      json = JSON.stringify(data);
+    } catch (stringErr) {
+      console.error('storage set stringify error:', stringErr);
+      return res.status(400).json({ error: 'Invalid JSON' });
+    }
     await query(
       `INSERT INTO storage(key, data)
-       VALUES ($1, $2)
+       VALUES ($1, $2::jsonb)
        ON CONFLICT (key) DO UPDATE SET data = EXCLUDED.data`,
-      [req.params.key, data]
+      [req.params.key, json]
     );
     res.sendStatus(204);
   } catch (err) {


### PR DESCRIPTION
## Summary
- Validate and parse request body strings before storage
- Stringify data and cast to jsonb when inserting into `storage` table
- Improve error handling for invalid JSON during stringification

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm ci` *(fails: 403 Forbidden fetching dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_68b8a550acbc8323bb0903f9a0a469e0