### PR TITLE
Handle existing email registration conflicts

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -77,7 +77,10 @@ app.post('/api/register', async (req, res) => {
   try {
     const existing = await query('SELECT 1 FROM users WHERE email=$1', [email]);
     if (existing.rowCount) {
-      return res.status(409).json({ error: 'המייל כבר רשום במערכת' });
+      return res.status(409).json({
+        error:
+          'המייל כבר רשום במערכת. האם תרצו להשתמש בכתובת מייל אחרת או לשחזר את הסיסמה?'
+      });
     }
 
     const password = crypto.randomBytes(8).toString('hex'); // שוקל לעבור ל-token reset

--- a/src/components/Auth/Login.tsx
+++ b/src/components/Auth/Login.tsx
@@ -164,6 +164,10 @@ const Login: React.FC = () => {
         isOpen={showRegister}
         onClose={() => setShowRegister(false)}
         mode="register"
+        onSwitchToReset={() => {
+          setShowRegister(false);
+          setShowReset(true);
+        }}
       />
     </div>
   );

--- a/src/components/common/DemoRequestModal.tsx
+++ b/src/components/common/DemoRequestModal.tsx
@@ -9,6 +9,8 @@ interface DemoRequestModalProps {
 const DemoRequestModal: React.FC<DemoRequestModalProps> = ({ isOpen, onClose }) => {
   const [email, setEmail] = useState("");
   const [sent, setSent] = useState(false);
+  const [error, setError] = useState("");
+  const [conflict, setConflict] = useState(false);
 
   if (!isOpen) return null;
 
@@ -23,14 +25,17 @@ const DemoRequestModal: React.FC<DemoRequestModalProps> = ({ isOpen, onClose }) 
       });
       console.log("Register request completed", res.status);
       if (!res.ok) {
-        const errorText = await res.text();
-        console.error("Registration failed", res.status, errorText);
+        const data = await res.json().catch(() => ({}));
+        setError(data.error || "אירעה שגיאה. נסו שוב.");
+        setConflict(res.status === 409);
         return;
       }
       console.log("Registration succeeded");
       setSent(true);
     } catch (err) {
       console.error("Registration error", err);
+      setError("אירעה שגיאה. נסו שוב.");
+      setConflict(false);
     }
   };
 
@@ -63,6 +68,29 @@ const DemoRequestModal: React.FC<DemoRequestModalProps> = ({ isOpen, onClose }) 
                 className="mt-1 w-full rounded-md border px-3 py-2"
               />
             </label>
+            {error && (
+              <div className="text-center text-sm text-red-600 space-y-2">
+                <p>{error}</p>
+                {conflict && (
+                  <div className="flex justify-center gap-4">
+                    <button
+                      type="button"
+                      className="underline"
+                      onClick={() => {
+                        setEmail("");
+                        setError("");
+                        setConflict(false);
+                      }}
+                    >
+                      השתמשו בכתובת אחרת
+                    </button>
+                    <a href="#/login" className="underline">
+                      שחזרו את הסיסמה
+                    </a>
+                  </div>
+                )}
+              </div>
+            )}
             <div className="flex justify-end gap-2">
               <button
                 type="button"


### PR DESCRIPTION
## Summary
- return detailed message when registering with an existing email
- show conflict errors in registration modals with options to use another email or reset password
- allow switching from registration modal directly to password reset

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b8c62029f48323875916406b78ee2f