### PR TITLE
feat: separate reset and already registered emails

### DIFF
--- a/src/components/Auth/EmailRequestModal.tsx
+++ b/src/components/Auth/EmailRequestModal.tsx
@@ -16,7 +16,8 @@ const EmailRequestModal: React.FC<EmailRequestModalProps> = ({ isOpen, onClose, 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      const res = await fetch(`${API_BASE_URL}/api/register`, {
+      const endpoint = mode === 'reset' ? '/api/password-reset' : '/api/register';
+      const res = await fetch(`${API_BASE_URL}${endpoint}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email })


### PR DESCRIPTION
## Summary
- send notification email when registration is attempted with an existing address
- add password reset endpoint and wire modal to call it

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8c6deb9c483238c3b242f08c020ad