### PR TITLE
feat: split reset and registration conflict emails

### DIFF
--- a/src/components/Auth/EmailRequestModal.tsx
+++ b/src/components/Auth/EmailRequestModal.tsx
@@ -19,7 +19,8 @@ const EmailRequestModal: React.FC<EmailRequestModalProps> = ({ isOpen, onClose, 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     try {
-      const res = await fetch(`${API_BASE_URL}/api/register`, {
+      const endpoint = mode === 'reset' ? '/api/reset' : '/api/register';
+      const res = await fetch(`${API_BASE_URL}${endpoint}`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ email })
@@ -27,7 +28,7 @@ const EmailRequestModal: React.FC<EmailRequestModalProps> = ({ isOpen, onClose, 
       if (!res.ok) {
         const data = await res.json().catch(() => ({}));
         setError(data.error || 'אירעה שגיאה. נסו שוב.');
-        setConflict(res.status === 409);
+        setConflict(mode === 'register' && res.status === 409);
         return;
       }
       setSent(true);


### PR DESCRIPTION
## Summary
- send notice when registration uses existing email
- add dedicated password reset endpoint
- update email request modal to call new reset API

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b8c7b3167c8323adfb599cbb3d1767