### PR TITLE
feat: add admin management features

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -323,6 +323,26 @@ app.put('/api/users/:email', async (req, res) => {
   }
 });
 
+app.get('/api/users', async (req, res) => {
+  try {
+    const { rows } = await query('SELECT email, gabbai_name AS "gabbaiName" FROM users');
+    res.json(rows);
+  } catch (err) {
+    console.error('list users error:', err);
+    res.status(500).json({ error: 'DB error' });
+  }
+});
+
+app.delete('/api/users/:email', async (req, res) => {
+  try {
+    await query('DELETE FROM users WHERE email=$1', [req.params.email]);
+    res.sendStatus(204);
+  } catch (err) {
+    console.error('delete user error:', err);
+    res.status(500).json({ error: 'DB error' });
+  }
+});
+
 app.get('/api/storage/:key', async (req, res) => {
   try {
     const { rows } = await query('SELECT data FROM storage WHERE key = $1', [req.params.key]);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -17,6 +17,8 @@ import ProPayment from './components/Pricing/ProPayment';
 import PaymentThankYou from './components/Pricing/PaymentThankYou';
 import PaymentCancelled from './components/Pricing/PaymentCancelled';
 import Home from './components/Home/Home';
+import UserManagement from './components/Admin/UserManagement';
+import DefaultMapView from './components/Admin/DefaultMapView';
 
 function App() {
   return (
@@ -39,6 +41,14 @@ function App() {
             }
           />
           <Route
+            path="/view"
+            element={
+              <AppProvider>
+                <MapView />
+              </AppProvider>
+            }
+          />
+          <Route
             path="/app"
             element={
               <RequireAuth>
@@ -51,6 +61,8 @@ function App() {
             <Route index element={<WorshiperManagement />} />
             <Route path="seats-manage" element={<SeatsManagement />} />
             <Route path="map-guide" element={<MapManagementGuide />} />
+            <Route path="admin-users" element={<UserManagement />} />
+            <Route path="default-map" element={<DefaultMapView />} />
             <Route path="contact" element={<Contact />} />
             <Route path="about" element={<About />} />
             <Route path="pricing" element={<Pricing />} />

--- a/src/components/Admin/DefaultMapView.tsx
+++ b/src/components/Admin/DefaultMapView.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import { useAppContext } from '../../context/AppContext';
+import { useServerStorage } from '../../hooks/useServerStorage';
+
+const DefaultMapView: React.FC = () => {
+  const { maps } = useAppContext();
+  const [defaultMapId, setDefaultMapId] = useServerStorage<string>('defaultMapId', '');
+
+  return (
+    <div>
+      <h2 className="text-2xl font-bold mb-4">מפת ברירת מחדל</h2>
+      <select
+        value={defaultMapId}
+        onChange={e => setDefaultMapId(e.target.value)}
+        className="border p-2 rounded"
+      >
+        <option value="">ללא</option>
+        {maps.map(map => (
+          <option key={map.id} value={map.id}>
+            {map.name}
+          </option>
+        ))}
+      </select>
+    </div>
+  );
+};
+
+export default DefaultMapView;

--- a/src/components/Admin/UserManagement.tsx
+++ b/src/components/Admin/UserManagement.tsx
@@ -1,0 +1,59 @@
+import React, { useEffect, useState } from 'react';
+import { API_BASE_URL } from '../../api';
+
+interface User {
+  email: string;
+  gabbaiName?: string;
+}
+
+const UserManagement: React.FC = () => {
+  const [users, setUsers] = useState<User[]>([]);
+
+  useEffect(() => {
+    fetch(`${API_BASE_URL}/api/users`)
+      .then(res => res.json())
+      .then(setUsers)
+      .catch(err => console.error('load users error', err));
+  }, []);
+
+  const handleDelete = async (email: string) => {
+    if (!window.confirm(`למחוק את ${email}?`)) return;
+    try {
+      await fetch(`${API_BASE_URL}/api/users/${email}`, { method: 'DELETE' });
+      setUsers(prev => prev.filter(u => u.email !== email));
+    } catch (err) {
+      console.error('delete user error', err);
+    }
+  };
+
+  return (
+    <div>
+      <h2 className="text-2xl font-bold mb-4">ניהול משתמשים</h2>
+      <table className="min-w-full">
+        <thead>
+          <tr>
+            <th className="text-right">מייל</th>
+            <th></th>
+          </tr>
+        </thead>
+        <tbody>
+          {users.map(user => (
+            <tr key={user.email} className="border-t">
+              <td className="py-2">{user.email}</td>
+              <td className="py-2 text-left">
+                <button
+                  className="text-red-600"
+                  onClick={() => handleDelete(user.email)}
+                >
+                  מחיקה
+                </button>
+              </td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default UserManagement;

--- a/src/components/Layout/Navbar.tsx
+++ b/src/components/Layout/Navbar.tsx
@@ -9,7 +9,9 @@ import {
   CreditCard,
   LogOut,
   Menu,
-  X
+  X,
+  UserMinus,
+  Map
 } from 'lucide-react';
 import { useAuth } from '../../context/AuthContext';
 import Logo from '../common/Logo';
@@ -25,6 +27,8 @@ const Navbar: React.FC = () => {
     { path: '/app', label: 'ניהול מתפללים', icon: Users },
     { path: '/app/seats-manage', label: 'ניהול מקומות', icon: Settings },
     { path: '/app/map-guide', label: 'מדריך מפה', icon: HelpCircle },
+    { path: '/app/admin-users', label: 'מחיקת משתמשים', icon: UserMinus },
+    { path: '/app/default-map', label: 'מפת ברירת מחדל', icon: Map },
     { path: '/app/contact', label: 'צור קשר', icon: Mail },
     { path: '/app/about', label: 'אודות', icon: Info },
     { path: '/app/pricing', label: 'מחירון', icon: CreditCard },

--- a/src/components/Seats/MapView.tsx
+++ b/src/components/Seats/MapView.tsx
@@ -2,9 +2,10 @@ import React, { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { useParams } from 'react-router-dom';
 import { useAppContext } from '../../context/AppContext';
 import { Seat, Worshiper } from '../../types';
+import { API_BASE_URL } from '../../api';
 
 const MapView: React.FC = () => {
-  const { id } = useParams<{ id: string }>();
+  const { id } = useParams<{ id?: string }>();
   const { benches, seats, loadMap, mapBounds, mapOffset, worshipers } = useAppContext();
   const containerRef = useRef<HTMLDivElement>(null);
   const [baseSize, setBaseSize] = useState({ width: 1200, height: 800 });
@@ -33,6 +34,15 @@ const MapView: React.FC = () => {
   useEffect(() => {
     if (id) {
       loadMap(id);
+    } else {
+      fetch(`${API_BASE_URL}/api/storage/defaultMapId`)
+        .then(res => res.json())
+        .then((mapId) => {
+          if (mapId) {
+            loadMap(mapId);
+          }
+        })
+        .catch(err => console.error('load default map error', err));
     }
   }, [id, loadMap]);
 


### PR DESCRIPTION
## Summary
- add API endpoints and UI for deleting users
- add admin page to set default map view
- load default map if no map ID provided

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b9568422c88323b7e2e7c8ef63fd04