### PR TITLE
Add user roles and restrict admin access

### DIFF
--- a/server/db.js
+++ b/server/db.js
@@ -20,9 +20,11 @@ export async function init() {
       synagogue_name text,
       address text,
       city text,
-      contact_phone text
+      contact_phone text,
+      role text NOT NULL DEFAULT 'demo'
     )
   `);
+  await pool.query(`ALTER TABLE users ADD COLUMN IF NOT EXISTS role text NOT NULL DEFAULT 'demo'`);
   await pool.query(`
     CREATE TABLE IF NOT EXISTS clients (
       client_id SERIAL PRIMARY KEY,

--- a/server/index.js
+++ b/server/index.js
@@ -98,8 +98,8 @@ app.post('/api/register', async (req, res) => {
 
     const password = generatePassword();
     await query(
-      `INSERT INTO users(email, password)
-       VALUES ($1, $2)`,
+      `INSERT INTO users(email, password, role)
+       VALUES ($1, $2, 'demo')`,
       [email, password]
     );
 
@@ -291,7 +291,7 @@ app.post('/api/login', async (req, res) => {
 
   try {
     const { rows } = await query(
-      `SELECT email, password, gabbai_name AS "gabbaiName", phone, synagogue_name AS "synagogueName", address, city, contact_phone AS "contactPhone" FROM users WHERE email=$1`,
+      `SELECT email, password, gabbai_name AS "gabbaiName", phone, synagogue_name AS "synagogueName", address, city, contact_phone AS "contactPhone", role FROM users WHERE email=$1`,
       [email]
     );
     const user = rows[0];
@@ -537,9 +537,9 @@ app.post('/api/zcredit/callback', async (req, res) => {
           if (email) {
             const password = generatePassword();
             await query(
-              `INSERT INTO users(email, password)
-               VALUES ($1, $2)
-               ON CONFLICT (email) DO UPDATE SET password = EXCLUDED.password`,
+              `INSERT INTO users(email, password, role)
+               VALUES ($1, $2, 'pro')
+               ON CONFLICT (email) DO UPDATE SET password = EXCLUDED.password, role = 'pro'`,
               [email, password]
             );
             const info = await transporter.sendMail({

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,7 @@ import PaymentCancelled from './components/Pricing/PaymentCancelled';
 import Home from './components/Home/Home';
 import UserManagement from './components/Admin/UserManagement';
 import DefaultMapView from './components/Admin/DefaultMapView';
+import RequireManager from './components/Auth/RequireManager';
 
 function App() {
   return (
@@ -61,8 +62,8 @@ function App() {
             <Route index element={<WorshiperManagement />} />
             <Route path="seats-manage" element={<SeatsManagement />} />
             <Route path="map-guide" element={<MapManagementGuide />} />
-            <Route path="admin-users" element={<UserManagement />} />
-            <Route path="default-map" element={<DefaultMapView />} />
+            <Route path="admin-users" element={<RequireManager><UserManagement /></RequireManager>} />
+            <Route path="default-map" element={<RequireManager><DefaultMapView /></RequireManager>} />
             <Route path="contact" element={<Contact />} />
             <Route path="about" element={<About />} />
             <Route path="pricing" element={<Pricing />} />

--- a/src/components/Auth/RequireManager.tsx
+++ b/src/components/Auth/RequireManager.tsx
@@ -1,0 +1,13 @@
+import React from 'react';
+import { Navigate } from 'react-router-dom';
+import { useAuth } from '../../context/AuthContext';
+
+const RequireManager: React.FC<{ children: JSX.Element }> = ({ children }) => {
+  const { user } = useAuth();
+  if (user?.role !== 'manager') {
+    return <Navigate to="/app" replace />;
+  }
+  return children;
+};
+
+export default RequireManager;

--- a/src/components/Layout/Navbar.tsx
+++ b/src/components/Layout/Navbar.tsx
@@ -27,12 +27,13 @@ const Navbar: React.FC = () => {
     { path: '/app', label: 'ניהול מתפללים', icon: Users },
     { path: '/app/seats-manage', label: 'ניהול מקומות', icon: Settings },
     { path: '/app/map-guide', label: 'מדריך מפה', icon: HelpCircle },
-    { path: '/app/admin-users', label: 'מחיקת משתמשים', icon: UserMinus },
-    { path: '/app/default-map', label: 'מפת ברירת מחדל', icon: Map },
+    { path: '/app/admin-users', label: 'מחיקת משתמשים', icon: UserMinus, admin: true },
+    { path: '/app/default-map', label: 'מפת ברירת מחדל', icon: Map, admin: true },
     { path: '/app/contact', label: 'צור קשר', icon: Mail },
     { path: '/app/about', label: 'אודות', icon: Info },
     { path: '/app/pricing', label: 'מחירון', icon: CreditCard },
   ];
+  const visibleNavItems = navItems.filter((item) => !item.admin || user?.role === 'manager');
 
   const handleLogout = () => {
     logout();
@@ -50,7 +51,7 @@ const Navbar: React.FC = () => {
           
           {/* Desktop Navigation */}
           <div className="hidden lg:flex items-center space-x-1 space-x-reverse">
-            {navItems.map((item) => {
+            {visibleNavItems.map((item) => {
               const Icon = item.icon;
               const isActive = location.pathname === item.path;
               return (
@@ -101,7 +102,7 @@ const Navbar: React.FC = () => {
         {isMobileMenuOpen && (
           <div className="lg:hidden border-t border-gray-200 py-4">
             <div className="space-y-2">
-              {navItems.map((item) => {
+              {visibleNavItems.map((item) => {
                 const Icon = item.icon;
                 const isActive = location.pathname === item.path;
                 return (

--- a/src/context/AuthContext.tsx
+++ b/src/context/AuthContext.tsx
@@ -10,6 +10,7 @@ interface User {
   address?: string;
   city?: string;
   contactPhone?: string;
+  role?: 'manager' | 'pro' | 'demo';
 }
 
 interface AuthContextType {


### PR DESCRIPTION
## Summary
- introduce role column for users with default demo
- add manager-only route guarding and navbar filtering
- upgrade users to pro upon paid credit callback

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b95967f53c83238abcf974d6b471cf