### PR TITLE
Display full user data cards on user deletion page

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -438,7 +438,18 @@ app.put('/api/users/:email', async (req, res) => {
 
 app.get('/api/users', async (req, res) => {
   try {
-    const { rows } = await query('SELECT email, gabbai_name AS "gabbaiName" FROM users');
+    const { rows } = await query(`
+      SELECT
+        email,
+        gabbai_name AS "gabbaiName",
+        phone,
+        synagogue_name AS "synagogueName",
+        address,
+        city,
+        contact_phone AS "contactPhone",
+        role
+      FROM users
+    `);
     res.json(rows);
   } catch (err) {
     console.error('list users error:', err);

--- a/src/components/Admin/UserManagement.tsx
+++ b/src/components/Admin/UserManagement.tsx
@@ -4,6 +4,12 @@ import { API_BASE_URL } from '../../api';
 interface User {
   email: string;
   gabbaiName?: string;
+  phone?: string;
+  synagogueName?: string;
+  address?: string;
+  city?: string;
+  contactPhone?: string;
+  role?: string;
 }
 
 const UserManagement: React.FC = () => {
@@ -29,29 +35,26 @@ const UserManagement: React.FC = () => {
   return (
     <div>
       <h2 className="text-2xl font-bold mb-4">ניהול משתמשים</h2>
-      <table className="min-w-full">
-        <thead>
-          <tr>
-            <th className="text-right">מייל</th>
-            <th></th>
-          </tr>
-        </thead>
-        <tbody>
-          {users.map(user => (
-            <tr key={user.email} className="border-t">
-              <td className="py-2">{user.email}</td>
-              <td className="py-2 text-left">
-                <button
-                  className="text-red-600"
-                  onClick={() => handleDelete(user.email)}
-                >
-                  מחיקה
-                </button>
-              </td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+      <div className="grid gap-4">
+        {users.map(user => (
+          <div key={user.email} className="border rounded p-4 shadow">
+            <div className="font-bold mb-2">{user.email}</div>
+            {user.gabbaiName && <div>גבאי: {user.gabbaiName}</div>}
+            {user.phone && <div>טלפון: {user.phone}</div>}
+            {user.synagogueName && <div>שם בית הכנסת: {user.synagogueName}</div>}
+            {user.address && <div>כתובת: {user.address}</div>}
+            {user.city && <div>עיר: {user.city}</div>}
+            {user.contactPhone && <div>טלפון איש קשר: {user.contactPhone}</div>}
+            {user.role && <div>תפקיד: {user.role}</div>}
+            <button
+              className="text-red-600 mt-2"
+              onClick={() => handleDelete(user.email)}
+            >
+              מחיקה
+            </button>
+          </div>
+        ))}
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Summary
- expand `/api/users` endpoint to return full user profile fields for management
- show each user's details in card form with delete option on admin page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68b95e6d09fc8323961bccbd6d08953a