### PR TITLE
Fix mismatched braces in SeatsManagement seat count section

### DIFF
--- a/src/components/Seats/SeatsManagement.tsx
+++ b/src/components/Seats/SeatsManagement.tsx
@@ -672,14 +672,14 @@ function SeatsManagement(): JSX.Element {
                       <MoreVertical className="h-4 w-4 text-gray-700"/>
                     </button>
 
-                    {/* Bench Label */
                     {/* Seat count badge (non-special) */}
                     {bench.type!=='special' && (
                       <div className="absolute -top-6 right-0 text-xxs text-gray-600 bg-white px-2 py-1 rounded shadow-sm">
                         {bench.seatCount ?? 0} מקומות
                       </div>
                     )}
-}
+
+                    {/* Bench Label */}
                     <div className="absolute -top-6 left-0 text-xs font-semibold text-gray-700 bg-white px-2 py-1 rounded shadow-sm">{bench.name}</div>
                     {/* Lock Indicator */}
                     {bench.locked && (<div className="absolute -top-2 -right-2 w-5 h-5 bg-red-500 rounded-full flex items-center justify-center"><Lock className="h-3 w-3 text-white"/></div>)}


### PR DESCRIPTION
## Summary
- correct JSX braces in SeatsManagement to render seat counts and bench labels properly

## Testing
- `npm run lint` *(fails: Unexpected any, no-unused-vars, missing deps, etc.)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba105a620c8323b2eb92e38ed471ac