### PR TITLE
Require double-click to assign worshiper to seat

### DIFF
--- a/src/components/Seats/SeatsManagement.tsx
+++ b/src/components/Seats/SeatsManagement.tsx
@@ -695,8 +695,8 @@ function SeatsManagement(): JSX.Element {
                           <div key={seat.id}
                                className={`absolute w-12 h-12 rounded-lg flex items-center justify-center text-xs text-white border-2 border-white cursor-pointer transition-all hover:scale-105 ${w ? 'bg-blue-500' : 'bg-gray-300'} ${selectedSeats.has(seat.id) ? 'ring-2 ring-yellow-400' : ''}`}
                                style={{ left: bench.orientation==='horizontal' ? idx*60+10 : 10, top: bench.orientation==='horizontal' ? 10 : idx*60+10 }}
-                               onClick={(e)=>handleSeatClick(seat.id, e)}
-                               title={w ? `${w.title} ${w.firstName} ${w.lastName}` : 'מקום פנוי - לחץ להקצאה'}>
+                               onDoubleClick={(e)=>handleSeatClick(seat.id, e)}
+                               title={w ? `${w.title} ${w.firstName} ${w.lastName}` : 'מקום פנוי - לחיצה כפולה להקצאה'}>
                             <span className="font-bold">{seat.id}</span>
                           </div>
                         );


### PR DESCRIPTION
## Summary
- require a double-click to assign a worshiper to a bench seat
- update seat tooltip to instruct double-click for assignment

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 19 errors, 7 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68ba1331de548323a33e762d1306be9b