### PR TITLE
Persist worshipers per user on server

### DIFF
--- a/server/routes/storage.js
+++ b/server/routes/storage.js
@@ -3,6 +3,12 @@ import { query } from '../db.js';
 export default function registerStorageRoutes(app) {
   app.get('/api/storage/:key', async (req, res) => {
     try {
+      const userEmail = req.header('x-user-email');
+      if (req.params.key.includes('-')) {
+        if (!userEmail || !req.params.key.startsWith(`${userEmail}-`)) {
+          return res.status(403).json({ error: 'Forbidden' });
+        }
+      }
       const { rows } = await query('SELECT data FROM storage WHERE key = $1', [req.params.key]);
       res.json(rows[0]?.data ?? null);
     } catch (err) {
@@ -10,9 +16,15 @@ export default function registerStorageRoutes(app) {
       res.status(500).json({ error: 'DB error' });
     }
   });
-  
+
   app.post('/api/storage/:key', async (req, res) => {
     try {
+      const userEmail = req.header('x-user-email');
+      if (req.params.key.includes('-')) {
+        if (!userEmail || !req.params.key.startsWith(`${userEmail}-`)) {
+          return res.status(403).json({ error: 'Forbidden' });
+        }
+      }
       await query(
         `INSERT INTO storage(key, data)
          VALUES ($1, $2::jsonb)

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -201,7 +201,7 @@ const generateSeatsFromBenches = (benches: Bench[]): Seat[] => {
 export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => {
   const { user } = useAuth();
   const userKey = user?.email ?? 'guest';
-  const [worshipers, setWorshipers] = useLocalStorage<Worshiper[]>('worshipers', [
+  const [worshipers, setWorshipers] = useServerStorage<Worshiper[]>('worshipers', [
     {
       id: '1',
       title: 'מר',

--- a/src/hooks/useServerStorage.ts
+++ b/src/hooks/useServerStorage.ts
@@ -17,7 +17,9 @@ export function useServerStorage<T>(
   useEffect(() => {
     const fetchValue = async () => {
       try {
-        const res = await fetch(`${API_BASE_URL}/api/storage/${storageKey}`);
+        const res = await fetch(`${API_BASE_URL}/api/storage/${storageKey}`, {
+          headers: userId ? { 'X-User-Email': userId } : undefined,
+        });
         if (res.ok) {
           const data = await res.json();
           if (data !== null) {
@@ -36,7 +38,10 @@ export function useServerStorage<T>(
     setStoredValue(valueToStore);
     fetch(`${API_BASE_URL}/api/storage/${storageKey}`, {
       method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
+      headers: {
+        'Content-Type': 'application/json',
+        ...(userId ? { 'X-User-Email': userId } : {}),
+      },
       body: JSON.stringify(valueToStore),
     }).catch(error => {
       console.error(`Error saving ${storageKey} to server:`, error);


### PR DESCRIPTION
## Summary
- Store worshiper lists on the server per user
- Secure storage endpoints by checking an `X-User-Email` header
- Send user email header in `useServerStorage` hook

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 27 problems)
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba15376d50832390c84ecb51741855