### PR TITLE
feat: allow pdf orientation selection

### DIFF
--- a/src/components/Seats/PdfToolbar.tsx
+++ b/src/components/Seats/PdfToolbar.tsx
@@ -4,13 +4,16 @@ import { exportMapToPDF, PdfMode, ColorMode } from './pdfUtils';
 interface PdfToolbarProps {
   wrapperRef: React.RefObject<HTMLDivElement>;
   mapLayerRef: React.RefObject<HTMLDivElement>;
+  /** optional id for the export button */
+  id?: string;
 }
 
-const PdfToolbar: React.FC<PdfToolbarProps> = ({ wrapperRef, mapLayerRef }) => {
+const PdfToolbar: React.FC<PdfToolbarProps> = ({ wrapperRef, mapLayerRef, id }) => {
   const [pdfMode, setPdfMode] = React.useState<PdfMode>('a4');
   const [colorMode, setColorMode] = React.useState<ColorMode>('color');
   const [hardBW, setHardBW] = React.useState(false);
   const [threshold, setThreshold] = React.useState(128);
+  const [orientation, setOrientation] = React.useState<'portrait' | 'landscape'>('portrait');
 
   const onExport = async () => {
     if (!wrapperRef.current || !mapLayerRef.current) return;
@@ -22,6 +25,7 @@ const PdfToolbar: React.FC<PdfToolbarProps> = ({ wrapperRef, mapLayerRef }) => {
       bwHard: hardBW,
       bwThreshold: threshold,
       marginsMm: 10,
+      orientation,
       fileName:
         (colorMode === 'bw' ? 'map-bw-' : 'map-color-') +
         (pdfMode === 'a4' ? 'a4.pdf' : 'onepage.pdf'),
@@ -81,7 +85,25 @@ const PdfToolbar: React.FC<PdfToolbarProps> = ({ wrapperRef, mapLayerRef }) => {
         </select>
       </label>
 
-      <button onClick={onExport} className="px-3 py-1 rounded bg-gray-200 hover:bg-gray-300">
+      {pdfMode === 'a4' && (
+        <label className="text-sm">
+          כיוון:
+          <select
+            value={orientation}
+            onChange={e => setOrientation(e.target.value as 'portrait' | 'landscape')}
+            className="ml-2 border rounded px-2 py-1"
+          >
+            <option value="portrait">אנכי</option>
+            <option value="landscape">אופקי</option>
+          </select>
+        </label>
+      )}
+
+      <button
+        id={id}
+        onClick={onExport}
+        className="px-3 py-1 rounded bg-gray-200 hover:bg-gray-300"
+      >
         ייצוא PDF
       </button>
     </div>

--- a/src/components/Seats/pdfUtils.ts
+++ b/src/components/Seats/pdfUtils.ts
@@ -53,6 +53,8 @@ export async function exportMapToPDF(opts: {
   mapLayerEl: HTMLElement;
   mode: PdfMode;
   colorMode: ColorMode;
+  /** Desired orientation for the generated PDF pages */
+  orientation?: 'portrait' | 'landscape';
   bwHard?: boolean;
   bwThreshold?: number;
   marginsMm?: number;
@@ -67,6 +69,7 @@ export async function exportMapToPDF(opts: {
     bwThreshold = 128,
     marginsMm = 10,
     fileName = 'map.pdf',
+    orientation,
   } = opts;
 
   mapLayerEl.classList.add('pdf-export');
@@ -80,14 +83,25 @@ export async function exportMapToPDF(opts: {
   if (mode === 'onePage') {
     const pageWmm = pxToMm(canvas.width);
     const pageHmm = pxToMm(canvas.height);
-    const orientation = pageWmm > pageHmm ? 'landscape' : 'portrait';
-    const pdf = new jsPDF({ orientation, unit: 'mm', format: [pageWmm, pageHmm], compress: false });
+    const autoOrientation = pageWmm > pageHmm ? 'landscape' : 'portrait';
+    const pdf = new jsPDF({
+      orientation: orientation || autoOrientation,
+      unit: 'mm',
+      format: [pageWmm, pageHmm],
+      compress: false,
+    });
     pdf.addImage(canvas.toDataURL('image/png'), 'PNG', 0, 0, pageWmm, pageHmm);
     pdf.save(fileName);
     return;
   }
 
-  const pdf = new jsPDF({ orientation: 'portrait', unit: 'mm', format: 'a4', compress: false });
+  const autoOrientation = canvas.width > canvas.height ? 'landscape' : 'portrait';
+  const pdf = new jsPDF({
+    orientation: orientation || autoOrientation,
+    unit: 'mm',
+    format: 'a4',
+    compress: false,
+  });
   const pageW = pdf.internal.pageSize.getWidth();
   const pageH = pdf.internal.pageSize.getHeight();
   const maxW = pageW - marginsMm * 2;


### PR DESCRIPTION
## Summary
- allow choosing portrait or landscape when exporting the map to PDF
- support optional button id for triggering export externally

## Testing
- `npm test` *(fails: Missing script "test")*
- `npx eslint src/components/Seats/pdfUtils.ts src/components/Seats/PdfToolbar.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ba18f33e0483239ad67fdbbfc4b971