### PR TITLE
feat: add zoom controls to map view

### DIFF
--- a/src/components/Seats/MapView.tsx
+++ b/src/components/Seats/MapView.tsx
@@ -3,12 +3,14 @@ import { useParams } from 'react-router-dom';
 import { useAppContext } from '../../context/AppContext';
 import { Seat, Worshiper } from '../../types';
 import { API_BASE_URL } from '../../api';
+import MapZoomControls from './MapZoomControls';
 
 const MapView: React.FC = () => {
   const { id } = useParams<{ id?: string }>();
   const { benches, seats, loadMap, mapBounds, mapOffset, worshipers } = useAppContext();
   const containerRef = useRef<HTMLDivElement>(null);
   const [baseSize, setBaseSize] = useState({ width: 1200, height: 800 });
+  const [zoom, setZoom] = useState(1);
 
   useEffect(() => {
     const originalPadding = document.body.style.padding;
@@ -61,13 +63,16 @@ const MapView: React.FC = () => {
   return (
     <div className="min-h-screen w-full overflow-auto bg-gray-100">
       <div ref={containerRef} className="relative h-screen w-full">
+        <div className="absolute top-4 right-4 z-10">
+          <MapZoomControls setZoom={setZoom} orientation="vertical" />
+        </div>
         <div
           className="absolute"
           style={{ width: baseSize.width + mapBounds.left + mapBounds.right, height: baseSize.height + mapBounds.top + mapBounds.bottom }}
         >
           <div
             className="absolute inset-0"
-            style={{ transform: `translate(${mapOffset.x}px, ${mapOffset.y}px)`, transformOrigin: 'top left' }}
+            style={{ transform: `translate(${mapOffset.x}px, ${mapOffset.y}px) scale(${zoom})`, transformOrigin: 'top left' }}
           >
             {benches.map(bench => (
             <div

--- a/src/components/Seats/MapZoomControls.tsx
+++ b/src/components/Seats/MapZoomControls.tsx
@@ -6,14 +6,19 @@ interface MapZoomControlsProps {
   onFit?: () => void;
   min?: number;
   max?: number;
+  orientation?: 'horizontal' | 'vertical';
 }
 
-const MapZoomControls: React.FC<MapZoomControlsProps> = ({ setZoom, onFit, min = 0.3, max = 3 }) => {
+const MapZoomControls: React.FC<MapZoomControlsProps> = ({ setZoom, onFit, min = 0.3, max = 3, orientation = 'horizontal' }) => {
   const zoomIn = () => setZoom(prev => Math.min(prev + 0.1, max));
   const zoomOut = () => setZoom(prev => Math.max(prev - 0.1, min));
 
+  const containerClass = orientation === 'vertical'
+    ? 'flex flex-col items-center space-y-2'
+    : 'flex items-center space-x-2 space-x-reverse';
+
   return (
-    <div className="flex items-center space-x-2 space-x-reverse">
+    <div className={containerClass}>
       <button
         onClick={zoomIn}
         className="p-2 rounded-lg bg-gray-100 text-gray-600 hover:bg-gray-200 transition-colors"


### PR DESCRIPTION
## Summary
- allow vertical orientation in `MapZoomControls`
- add zoom state and control buttons to `MapView` for manual zooming

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: 18 errors, 8 warnings)*
- `npx eslint src/components/Seats/MapView.tsx src/components/Seats/MapZoomControls.tsx`


------
https://chatgpt.com/codex/tasks/task_e_68ba1b276d2083239237a078dd56c8aa