### PR TITLE
fix: import Printer icon

### DIFF
--- a/src/components/Worshipers/WorshiperManagement.tsx
+++ b/src/components/Worshipers/WorshiperManagement.tsx
@@ -1,7 +1,7 @@
 import React, { useState, useRef } from 'react';
 import { Worshiper } from '../../types';
 import { useAppContext } from '../../context/AppContext';
-import { Plus, Edit2, Trash2, Save, X, User as UserIcon, Upload, Download, MapPin, FileText, ArrowUp, CreditCard } from 'lucide-react';
+import { Plus, Edit2, Trash2, Save, X, User as UserIcon, Upload, Download, MapPin, FileText, ArrowUp, CreditCard, Printer } from 'lucide-react';
 import WorshiperSeatsForm from './WorshiperSeatsForm';
 import WorshiperItemsForm from './WorshiperItemsForm';
 


### PR DESCRIPTION
## Summary
- add missing Printer icon import in Worshiper management so label printing works without reference errors

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: 18 errors, 8 warnings)
- `npx eslint src/components/Worshipers/WorshiperManagement.tsx`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68ba1de31bbc8323b3162092d0555c6a