### PR TITLE
fix: import missing MoreVertical icon

### DIFF
--- a/src/components/Seats/SeatsManagement.tsx
+++ b/src/components/Seats/SeatsManagement.tsx
@@ -7,7 +7,7 @@ import PdfToolbar from './PdfToolbar';
 import {
   Plus, Grid3X3, BoxSelect, Hand, ListOrdered, Save, Trash2, Lock, Unlock, RotateCw, Copy,
   ArrowRight, ArrowDown, ArrowDownRight, Eye, EyeOff, Palette, MousePointer, Layers, Download,
-  Upload, Maximize2, Grid as GridIcon, Target, Printer
+  Upload, Maximize2, Grid as GridIcon, Target, Printer, MoreVertical
 } from 'lucide-react';
 
 /**


### PR DESCRIPTION
## Summary
- fix runtime crash by importing `MoreVertical` icon for map menu

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68ba28f5ece883238557a2abf911257f