### PR TITLE
Abort label PDF creation when font missing

### DIFF
--- a/src/components/Worshipers/WorshiperManagement.tsx
+++ b/src/components/Worshipers/WorshiperManagement.tsx
@@ -109,7 +109,8 @@ const WorshiperManagement: React.FC = () => {
       pdf.addFont('NotoSansHebrew.ttf', 'NotoHeb', 'normal');
       pdf.setFont('NotoHeb');
     } catch (err) {
-      console.error('Failed to load custom font, using default', err);
+      console.error('Failed to load custom font, aborting PDF generation', err);
+      return;
     }
 
     const pageW = pdf.internal.pageSize.getWidth();


### PR DESCRIPTION
## Summary
- Avoid runtime jsPDF errors by bailing out when the custom Hebrew font cannot be loaded

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc95f1da748323af963445ecdaa130