### PR TITLE
Display worshipper name on assigned seats with padding

### DIFF
--- a/src/components/Seats/SeatsManagement.tsx
+++ b/src/components/Seats/SeatsManagement.tsx
@@ -764,13 +764,15 @@ function SeatsManagement(): JSX.Element {
                               });
                             }}
                             onDoubleClick={(e)=>handleSeatClick(seat.id, e)}
-                            title={w ? `${w.title} ${w.firstName} ${w.lastName}` : 'מקום פנוי - לחיצה כפולה להקצאה'}
+                            title={w ? `${w.title ? w.title + ' ' : ''}${w.firstName} ${w.lastName}` : 'מקום פנוי - לחיצה כפולה להקצאה'}
                           >
-                            <span className="font-bold">{seat.id}</span>
+                            <span className={`font-bold text-center ${w ? 'p-1 text-[10px] leading-tight' : ''}`}>
+                              {w ? `${w.title ? w.title + ' ' : ''}${w.firstName} ${w.lastName}` : seat.id}
+                            </span>
                           </div>
-                        );
-                      })
-                    )}
+                          );
+                        })
+                      )}
                     {/* Resize handle hint for special */}
                     {bench.type==='special' && selected && (<div className="absolute -bottom-2 -right-2 w-4 h-4 bg-blue-500 rounded-full cursor-se-resize"><ArrowDownRight className="h-3 w-3 text-white m-0.5"/></div>)}
                   </div>


### PR DESCRIPTION
## Summary
- show assigned worshipper's full name on seat tiles
- add padding and smaller text to prevent name from touching seat edges

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc9a2cf44083239682a6dd0f58bde7