### PR TITLE
feat: view worshiper details in styled card

### DIFF
--- a/src/components/Worshipers/WorshiperCard.tsx
+++ b/src/components/Worshipers/WorshiperCard.tsx
@@ -1,0 +1,64 @@
+import React from 'react';
+import { X, Phone, Mail, MapPin, User as UserIcon, Users } from 'lucide-react';
+import { Worshiper } from '../../types';
+
+interface Props {
+  worshiper: Worshiper;
+  onClose: () => void;
+}
+
+const WorshiperCard: React.FC<Props> = ({ worshiper, onClose }) => {
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50">
+      <div className="relative bg-white rounded-xl shadow-lg w-full max-w-md p-6">
+        <button
+          onClick={onClose}
+          className="absolute top-3 left-3 text-gray-400 hover:text-gray-600"
+        >
+          <X className="h-5 w-5" />
+        </button>
+
+        <div className="text-center mb-6">
+          <div className="w-16 h-16 rounded-full bg-blue-100 flex items-center justify-center mx-auto mb-3">
+            <UserIcon className="h-8 w-8 text-blue-600" />
+          </div>
+          <h2 className="text-xl font-semibold text-gray-800">
+            {worshiper.title} {worshiper.firstName} {worshiper.lastName}
+          </h2>
+        </div>
+
+        <div className="space-y-3 text-gray-700 text-sm">
+          <div className="flex items-center">
+            <MapPin className="h-4 w-4 ml-2 text-gray-500" />
+            <span>
+              {worshiper.address}
+              {worshiper.city ? `, ${worshiper.city}` : ''}
+            </span>
+          </div>
+          <div className="flex items-center">
+            <Phone className="h-4 w-4 ml-2 text-gray-500" />
+            <span>{worshiper.phone}</span>
+          </div>
+          {worshiper.secondaryPhone && (
+            <div className="flex items-center">
+              <Phone className="h-4 w-4 ml-2 text-gray-500" />
+              <span>{worshiper.secondaryPhone}</span>
+            </div>
+          )}
+          {worshiper.email && (
+            <div className="flex items-center">
+              <Mail className="h-4 w-4 ml-2 text-gray-500" />
+              <span>{worshiper.email}</span>
+            </div>
+          )}
+          <div className="flex items-center">
+            <Users className="h-4 w-4 ml-2 text-gray-500" />
+            <span>כמות מקומות: {worshiper.seatCount}</span>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default WorshiperCard;

--- a/src/components/Worshipers/WorshiperManagement.tsx
+++ b/src/components/Worshipers/WorshiperManagement.tsx
@@ -4,6 +4,7 @@ import { useAppContext } from '../../context/AppContext';
 import { Plus, Edit2, Trash2, Save, X, User as UserIcon, Upload, Download, MapPin, FileText, ArrowUp, CreditCard, Printer } from 'lucide-react';
 import WorshiperSeatsForm from './WorshiperSeatsForm';
 import WorshiperItemsForm from './WorshiperItemsForm';
+import WorshiperCard from './WorshiperCard';
 import { printLabels } from '../../utils/printLabels';
 
 const WorshiperManagement: React.FC = () => {
@@ -14,6 +15,7 @@ const WorshiperManagement: React.FC = () => {
   const [promisesWorshiper, setPromisesWorshiper] = useState<Worshiper | null>(null);
   const [aliyotWorshiper, setAliyotWorshiper] = useState<Worshiper | null>(null);
   const [placesWorshiper, setPlacesWorshiper] = useState<Worshiper | null>(null);
+  const [viewWorshiper, setViewWorshiper] = useState<Worshiper | null>(null);
   const [formData, setFormData] = useState<Partial<Worshiper>>({
     title: '',
     firstName: '',
@@ -366,7 +368,11 @@ const WorshiperManagement: React.FC = () => {
             </thead>
             <tbody>
               {worshipers.map((w) => (
-                <tr key={w.id} className="border-t hover:bg-gray-50">
+                <tr
+                  key={w.id}
+                  className="border-t hover:bg-gray-50 cursor-pointer"
+                  onClick={() => setViewWorshiper(w)}
+                >
                   <td className="px-4 py-2">
                     <div className="flex items-center space-x-2 space-x-reverse">
                       <UserIcon className="h-5 w-5 text-blue-600" />
@@ -382,7 +388,10 @@ const WorshiperManagement: React.FC = () => {
                   <td className="px-4 py-2">
                     <div className="flex space-x-2 space-x-reverse">
                       <button
-                        onClick={() => setSeatWorshiper(w)}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setSeatWorshiper(w);
+                        }}
                         disabled={isAdding || editingWorshiper}
                         className="p-2 text-green-600 hover:bg-green-50 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                         title="הקצאת מקומות"
@@ -390,7 +399,10 @@ const WorshiperManagement: React.FC = () => {
                         <MapPin className="h-4 w-4" />
                       </button>
                       <button
-                        onClick={() => setPromisesWorshiper(w)}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setPromisesWorshiper(w);
+                        }}
                         disabled={isAdding || editingWorshiper}
                         className="p-2 text-purple-600 hover:bg-purple-50 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                         title="הבטחות"
@@ -398,7 +410,10 @@ const WorshiperManagement: React.FC = () => {
                         <FileText className="h-4 w-4" />
                       </button>
                       <button
-                        onClick={() => setAliyotWorshiper(w)}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setAliyotWorshiper(w);
+                        }}
                         disabled={isAdding || editingWorshiper}
                         className="p-2 text-indigo-600 hover:bg-indigo-50 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                         title="עליות"
@@ -406,7 +421,10 @@ const WorshiperManagement: React.FC = () => {
                         <ArrowUp className="h-4 w-4" />
                       </button>
                       <button
-                        onClick={() => setPlacesWorshiper(w)}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          setPlacesWorshiper(w);
+                        }}
                         disabled={isAdding || editingWorshiper}
                         className="p-2 text-teal-600 hover:bg-teal-50 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                         title="מקומות"
@@ -414,7 +432,10 @@ const WorshiperManagement: React.FC = () => {
                         <CreditCard className="h-4 w-4" />
                       </button>
                       <button
-                        onClick={() => handleEditWorshiper(w)}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleEditWorshiper(w);
+                        }}
                         disabled={isAdding || editingWorshiper}
                         className="p-2 text-blue-600 hover:bg-blue-50 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                         title="עריכה"
@@ -422,7 +443,10 @@ const WorshiperManagement: React.FC = () => {
                         <Edit2 className="h-4 w-4" />
                       </button>
                       <button
-                        onClick={() => handleDeleteWorshiper(w.id)}
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          handleDeleteWorshiper(w.id);
+                        }}
                         disabled={isAdding || editingWorshiper}
                         className="p-2 text-red-600 hover:bg-red-50 rounded-lg transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
                         title="מחיקה"
@@ -472,6 +496,12 @@ const WorshiperManagement: React.FC = () => {
         field="places"
         title="מקומות"
         onClose={() => setPlacesWorshiper(null)}
+      />
+    )}
+    {viewWorshiper && (
+      <WorshiperCard
+        worshiper={viewWorshiper}
+        onClose={() => setViewWorshiper(null)}
       />
     )}
     </>


### PR DESCRIPTION
## Summary
- style the worshiper card with icons and improved layout
- open worshiper card when clicking a row while preserving action buttons

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bc9e147740832383558aac341751de