### PR TITLE
Add request and CORS logging to server

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -13,6 +13,17 @@ import registerZCreditRoutes from './routes/zcredit.js';
 
 const app = express();
 
+// Basic request logging
+app.use((req, res, next) => {
+  const start = Date.now();
+  console.log('Incoming request', req.method, req.originalUrl, 'origin:', req.headers.origin);
+  res.on('finish', () => {
+    const duration = Date.now() - start;
+    console.log('Handled', req.method, req.originalUrl, '->', res.statusCode, `${duration}ms`);
+  });
+  next();
+});
+
 const generatePassword = () =>
   crypto.randomInt(0, 1_000_000).toString().padStart(6, '0');
 
@@ -42,8 +53,13 @@ const allowedOrigins = [
 
 const corsConfig = {
   origin(origin, cb) {
+    console.log('CORS check for', origin);
     if (!origin) return cb(null, true);
-    if (allowedOrigins.includes(origin)) return cb(null, true);
+    if (allowedOrigins.includes(origin)) {
+      console.log('CORS allowed:', origin);
+      return cb(null, true);
+    }
+    console.log('CORS denied:', origin);
     return cb(null, false); // ✅ לא Error
   },
   credentials: true,


### PR DESCRIPTION
## Summary
- log incoming requests and response status
- log CORS origin checks and allow/deny decisions

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bcaa3032788323b7bcf577982616b5