### PR TITLE
chore: add storage route logging

### DIFF
--- a/server/routes/storage.js
+++ b/server/routes/storage.js
@@ -5,6 +5,7 @@ export default function registerStorageRoutes(app) {
   app.get('/api/storage/:key', async (req, res) => {
     try {
       const userEmail = req.header('x-user-email');
+      console.log('storage get', { key: req.params.key, userEmail });
       if (req.params.key.includes('-')) {
         if (!userEmail || !req.params.key.startsWith(`${userEmail}-`)) {
           return res.status(403).json({ error: 'Forbidden' });
@@ -13,7 +14,10 @@ export default function registerStorageRoutes(app) {
       const { rows } = await query('SELECT data FROM storage WHERE key = $1', [req.params.key]);
       return res.status(200).json(rows[0]?.data ?? null);
     } catch (err) {
-      console.error('storage get error:', err);
+      console.error('storage get error:', err, {
+        key: req.params.key,
+        userEmail: req.header('x-user-email')
+      });
       return res.status(500).json({ error: 'DB error' });
     }
   });
@@ -22,6 +26,7 @@ export default function registerStorageRoutes(app) {
   app.post('/api/storage/mget', express.json(), async (req, res) => {
     try {
       const { keys } = req.body || {};
+      console.log('storage mget', { keys });
       if (!Array.isArray(keys) || !keys.length) {
         return res.status(400).json({ error: 'keys[] is required' });
       }
@@ -33,7 +38,7 @@ export default function registerStorageRoutes(app) {
       const map = Object.fromEntries(rows.map((r) => [r.key, r.data]));
       return res.status(200).json({ values: map });
     } catch (err) {
-      console.error('storage mget error:', err);
+      console.error('storage mget error:', err, { keys: req.body?.keys });
       return res.status(500).json({ error: 'DB error' });
     }
   });
@@ -41,6 +46,7 @@ export default function registerStorageRoutes(app) {
   app.post('/api/storage/:key', express.json(), async (req, res) => {
     try {
       const userEmail = req.header('x-user-email');
+      console.log('storage set', { key: req.params.key, userEmail, body: req.body });
       if (req.params.key.includes('-')) {
         if (!userEmail || !req.params.key.startsWith(`${userEmail}-`)) {
           return res.status(403).json({ error: 'Forbidden' });
@@ -54,7 +60,11 @@ export default function registerStorageRoutes(app) {
       );
       return res.status(200).json({ ok: true });
     } catch (err) {
-      console.error('storage set error:', err);
+      console.error('storage set error:', err, {
+        key: req.params.key,
+        userEmail: req.header('x-user-email'),
+        body: req.body
+      });
       return res.status(500).json({ error: 'DB error' });
     }
   });


### PR DESCRIPTION
## Summary
- add debug logs for storage get/set/mget routes
- include key and user info on error

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68bcbf78acd88323b8d439d94f796b57