### PR TITLE
Improve font loading validation in label PDF generator

### DIFF
--- a/src/utils/printLabels.ts
+++ b/src/utils/printLabels.ts
@@ -25,7 +25,10 @@ export async function printLabels({ benches, seats, worshipers }: LabelPrintOpti
 
   try {
     const res = await fetch('/fonts/NotoSansHebrew.ttf');
-    if (!res.ok) throw new Error('Font request failed');
+    const contentType = res.headers.get('Content-Type') || '';
+    if (!res.ok || !contentType.includes('font')) {
+      throw new Error('Font request failed');
+    }
     const buf = await res.arrayBuffer();
     const base64 = arrayBufferToBase64(buf);
     pdf.addFileToVFS('NotoSansHebrew.ttf', base64);


### PR DESCRIPTION
## Summary
- avoid jsPDF errors by checking the response content type before adding custom font

## Testing
- `npm test` (fails: Missing script)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bcc08c6c24832383952d366c06f620