### PR TITLE
Fix jsPDF font loading

### DIFF
--- a/src/types/external.d.ts
+++ b/src/types/external.d.ts
@@ -2,6 +2,16 @@ declare module 'jspdf' {
   export class jsPDF {
     constructor(options?: unknown);
     addImage(...args: unknown[]): void;
+    addPage(): void;
+    addFileToVFS(filename: string, filecontent: string): void;
+    addFont(postScriptName: string, id: string, fontStyle: string): void;
+    setFont(fontName: string): void;
+    setFontSize(size: number): void;
+    text(text: string, x: number, y: number, options?: unknown): void;
+    getFontList(): Record<string, unknown>;
+    internal: {
+      pageSize: { getWidth(): number; getHeight(): number };
+    };
     save(filename?: string): void;
   }
 }


### PR DESCRIPTION
## Summary
- fix labels PDF generation by converting TTF font to binary string and validating registration before use
- expand jsPDF TypeScript definitions to include font helpers

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bcc41956fc83238725d1b1147e202a