### PR TITLE
Hide grid and controls in PDF export

### DIFF
--- a/src/components/Seats/MapView.tsx
+++ b/src/components/Seats/MapView.tsx
@@ -63,7 +63,7 @@ const MapView: React.FC = () => {
   return (
     <div className="min-h-screen w-full overflow-auto bg-gray-100">
       <div ref={containerRef} className="relative h-screen w-full">
-        <div className="absolute top-4 right-4 z-10">
+        <div className="absolute top-4 right-4 z-10 pdf-hide">
           <MapZoomControls setZoom={setZoom} orientation="vertical" />
         </div>
         <div

--- a/src/components/Seats/SeatsManagement.tsx
+++ b/src/components/Seats/SeatsManagement.tsx
@@ -590,7 +590,7 @@ function SeatsManagement(): JSX.Element {
           </div>
 
           {/* Zoom */}
-          <div className="mr-auto"><MapZoomControls setZoom={setZoom} onFit={fitToScreen} /></div>
+          <div className="mr-auto pdf-hide"><MapZoomControls setZoom={setZoom} onFit={fitToScreen} /></div>
         </div>
       </div>
 
@@ -703,7 +703,7 @@ function SeatsManagement(): JSX.Element {
             {/* Grid */}
             {gridSettings.showGrid && (
               <div
-                className="absolute inset-0 opacity-20 pointer-events-none"
+                className="absolute inset-0 opacity-20 pointer-events-none pdf-hide"
                 style={{
                   backgroundImage: `linear-gradient(to right, #3B82F6 1px, transparent 1px), linear-gradient(to bottom, #3B82F6 1px, transparent 1px)`,
                   backgroundSize: `${gridSettings.gridSize * zoom}px ${gridSettings.gridSize * zoom}px`,
@@ -792,13 +792,13 @@ function SeatsManagement(): JSX.Element {
 
               {/* selection rectangle */}
               {isSelecting && selectionRect && (
-                <div className="absolute border-2 border-blue-400 bg-blue-200/20 pointer-events-none"
+                <div className="absolute border-2 border-blue-400 bg-blue-200/20 pointer-events-none pdf-hide"
                      style={{ left: selectionRect.x + mapBounds.left, top: selectionRect.y + mapBounds.top, width: selectionRect.width, height: selectionRect.height }}/>
               )}
             </div>
 
             {/* Status Bar */}
-            <div className="absolute bottom-4 left-4 bg-white/90 backdrop-blur-sm rounded-xl px-4 py-2 shadow-lg border border-gray-200">
+            <div className="absolute bottom-4 left-4 bg-white/90 backdrop-blur-sm rounded-xl px-4 py-2 shadow-lg border border-gray-200 pdf-hide">
               <div className="flex items-center gap-4 text-sm text-gray-600">
                 <span>זום: {Math.round(zoom*100)}%</span>
                 <span>ספסלים: {benches.length}</span>

--- a/src/components/Seats/pdfUtils.ts
+++ b/src/components/Seats/pdfUtils.ts
@@ -11,15 +11,23 @@ function pxToMm(px: number, dpi = DPI_FOR_MM) {
   return (px / dpi) * MM_PER_INCH;
 }
 
-async function renderWrapperToCanvas(wrapperEl: HTMLElement) {
-  const fullWidth = wrapperEl.scrollWidth || wrapperEl.clientWidth;
-  const fullHeight = wrapperEl.scrollHeight || wrapperEl.clientHeight;
+async function renderWrapperToCanvas(wrapperEl: HTMLElement, mapLayerEl: HTMLElement) {
+  const fullWidth = Math.max(
+    wrapperEl.scrollWidth || wrapperEl.clientWidth,
+    mapLayerEl.scrollWidth || mapLayerEl.clientWidth
+  );
+  const fullHeight = Math.max(
+    wrapperEl.scrollHeight || wrapperEl.clientHeight,
+    mapLayerEl.scrollHeight || mapLayerEl.clientHeight
+  );
 
   return await html2canvas(wrapperEl, {
     width: fullWidth,
     height: fullHeight,
     windowWidth: fullWidth,
     windowHeight: fullHeight,
+    scrollX: 0,
+    scrollY: 0,
     scale: 3,
     useCORS: true,
     backgroundColor: '#ffffff',
@@ -72,9 +80,11 @@ export async function exportMapToPDF(opts: {
     orientation,
   } = opts;
 
+  wrapperEl.classList.add('pdf-exporting');
   mapLayerEl.classList.add('pdf-export');
-  let canvas = await renderWrapperToCanvas(wrapperEl);
+  let canvas = await renderWrapperToCanvas(wrapperEl, mapLayerEl);
   mapLayerEl.classList.remove('pdf-export');
+  wrapperEl.classList.remove('pdf-exporting');
 
   if (colorMode === 'bw') {
     canvas = toGrayscaleCanvas(canvas, bwHard, bwThreshold);

--- a/src/index.css
+++ b/src/index.css
@@ -31,6 +31,11 @@ body {
   transform: none !important;
 }
 
+/* Hide UI elements during PDF export */
+.pdf-exporting .pdf-hide {
+  display: none !important;
+}
+
 @layer utilities {
   @keyframes fade-in-up {
     0% {


### PR DESCRIPTION
## Summary
- hide non-map UI elements during PDF export with new css class
- compute full map size and toggle export classes while rendering PDF

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68bd2e3b4904832398ff6d56bc289a22