### PR TITLE
fix: improve label font loading

### DIFF
--- a/public/fonts/.gitkeep
+++ b/public/fonts/.gitkeep
@@ -1,0 +1,1 @@
+# Placeholder for font files used by jsPDF

--- a/src/utils/printLabels.ts
+++ b/src/utils/printLabels.ts
@@ -37,8 +37,9 @@ export async function printLabels({ benches = [], seats = [], worshipers = [], s
   for (const font of fonts) {
     try {
       const res = await fetch(font.url);
-      const contentType = res.headers.get('Content-Type') || '';
-      if (!res.ok || !contentType.includes('font')) {
+      // Some servers might not set a specific font content-type.
+      // As long as the request succeeds, assume the response is a font file.
+      if (!res.ok) {
         continue;
       }
       const buf = await res.arrayBuffer();
@@ -50,7 +51,8 @@ export async function printLabels({ benches = [], seats = [], worshipers = [], s
         customFontLoaded = true;
         break;
       }
-    } catch {
+    } catch (err) {
+      console.warn('Failed to load font', font.url, err);
       // Try the next font
     }
   }


### PR DESCRIPTION
## Summary
- make Hebrew font loading more tolerant of missing content-type
- document public/fonts directory for supplying custom fonts

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd2f179e0483238af9b18410d15cdb