### PR TITLE
feat: print map-specific labels

### DIFF
--- a/src/components/Seats/SeatsManagement.tsx
+++ b/src/components/Seats/SeatsManagement.tsx
@@ -498,7 +498,21 @@ function SeatsManagement(): JSX.Element {
               <button onClick={()=>loadMap(m.id)} className="flex-1 text-right hover:underline">{m.name}</button>
               <button onClick={()=>{ const name=window.prompt('שנה שם מפה:', m.name); if (name) renameMap(m.id, name); }} title="שנה שם" className="p-1 rounded hover:bg-gray-100"><span className="text-xs">שם</span></button>
               <button onClick={()=>PdfToolbar && mapLayerRef.current && wrapperRef.current && (document.querySelector('#pdfExportBtn') as HTMLButtonElement)?.click()} title="הדפס מפה" className="p-1 rounded hover:bg-gray-100"><Printer className="h-4 w-4" /></button>
-              <button onClick={()=>printLabels({ benches: m.benches, seats: m.seats, worshipers, stickers: m.stickers })} title="הדפס מדבקות" className="p-1 rounded hover:bg-gray-100"><FileText className="h-4 w-4" /></button>
+              <button
+                onClick={() =>
+                  printLabels({
+                    benches: m.benches,
+                    seats: m.seats,
+                    worshipers,
+                    stickers: m.stickers,
+                    fileName: `labels-${m.name.replace(/\s+/g, '-')}.pdf`,
+                  })
+                }
+                title="הדפס מדבקות"
+                className="p-1 rounded hover:bg-gray-100"
+              >
+                <FileText className="h-4 w-4" />
+              </button>
             </div>
           ))}
         </div>

--- a/src/components/Worshipers/WorshiperManagement.tsx
+++ b/src/components/Worshipers/WorshiperManagement.tsx
@@ -8,7 +8,7 @@ import WorshiperCard from './WorshiperCard';
 import { printLabels } from '../../utils/printLabels';
 
 const WorshiperManagement: React.FC = () => {
-  const { worshipers, setWorshipers, seats, benches } = useAppContext();
+  const { worshipers, setWorshipers, maps } = useAppContext();
   const [isAdding, setIsAdding] = useState(false);
   const [editingWorshiper, setEditingWorshiper] = useState<string | null>(null);
   const [seatWorshiper, setSeatWorshiper] = useState<Worshiper | null>(null);
@@ -82,7 +82,15 @@ const WorshiperManagement: React.FC = () => {
   };
 
   const handlePrintLabels = async () => {
-    await printLabels({ benches, seats, worshipers });
+    for (const map of maps) {
+      await printLabels({
+        benches: map.benches,
+        seats: map.seats,
+        worshipers,
+        stickers: map.stickers,
+        fileName: `labels-${map.name.replace(/\s+/g, '-')}.pdf`,
+      });
+    }
   };
 
   const handleSaveWorshiper = () => {

--- a/src/utils/printLabels.ts
+++ b/src/utils/printLabels.ts
@@ -21,9 +21,13 @@ interface LabelPrintOptions {
   seats?: Seat[];
   worshipers?: Worshiper[];
   stickers?: Sticker[];
+  /**
+   * Optional file name for the generated PDF. Defaults to `labels.pdf`.
+   */
+  fileName?: string;
 }
 
-export async function printLabels({ benches = [], seats = [], worshipers = [], stickers }: LabelPrintOptions): Promise<void> {
+export async function printLabels({ benches = [], seats = [], worshipers = [], stickers, fileName = 'labels.pdf' }: LabelPrintOptions): Promise<void> {
   const pdf = new jsPDF({ orientation: 'portrait', unit: 'mm', format: 'a4' });
 
   // Try to load an available font for Hebrew text. We attempt a list of
@@ -100,7 +104,7 @@ export async function printLabels({ benches = [], seats = [], worshipers = [], s
     pdf.text(rtl(label.benchName), x + labelW / 2, y + labelH / 2 + 6, { align: 'center' });
   });
 
-  pdf.save('labels.pdf');
+  pdf.save(fileName);
 }
 
 export default printLabels;


### PR DESCRIPTION
## Summary
- allow label printer to accept custom file names
- print map stickers with unique file names per map
- enable worshiper management to batch-print labels for each map

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bd449617f08323b94a740111f716ac