### PR TITLE
Remove seat numbers from vacant seats

### DIFF
--- a/src/components/Seats/SeatsManagement.tsx
+++ b/src/components/Seats/SeatsManagement.tsx
@@ -792,7 +792,7 @@ function SeatsManagement(): JSX.Element {
                             title={w ? `${w.title ? w.title + ' ' : ''}${w.firstName} ${w.lastName}` : 'מקום פנוי - לחיצה כפולה להקצאה'}
                           >
                             <span className={`font-bold text-center ${w ? 'p-1 text-[10px] leading-tight' : ''}`}>
-                              {w ? `${w.title ? w.title + ' ' : ''}${w.firstName} ${w.lastName}` : seat.id}
+                              {w ? `${w.title ? w.title + ' ' : ''}${w.firstName} ${w.lastName}` : ''}
                             </span>
                           </div>
                           );


### PR DESCRIPTION
## Summary
- Hide numeric labels for empty seats in seat management view

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd467fc74483238ed52a033cd4343b