### PR TITLE
Generate stickers for label printing

### DIFF
--- a/src/components/Seats/SeatsManagement.tsx
+++ b/src/components/Seats/SeatsManagement.tsx
@@ -525,7 +525,16 @@ function SeatsManagement(): JSX.Element {
                     benches: m.benches,
                     seats: m.seats,
                     worshipers,
-                    stickers: m.stickers,
+                    stickers: m.seats.map((seat) => {
+                      const w = worshipers.find((w) => w.id === seat.userId);
+                      const bench = m.benches.find((b) => b.id === seat.benchId);
+                      return {
+                        name: w
+                          ? `${w.title ? w.title + ' ' : ''}${w.firstName} ${w.lastName}`
+                          : 'פנוי',
+                        benchName: bench?.name || '',
+                      };
+                    }),
                     fileName: `labels-${m.name.replace(/\s+/g, '-')}.pdf`,
                   })
                 }


### PR DESCRIPTION
## Summary
- generate label stickers from seats and worshipers when printing

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bd4af2def48323931b879f2b92d824