### PR TITLE
Fix PDF export scaling

### DIFF
--- a/src/components/Seats/PdfToolbar.tsx
+++ b/src/components/Seats/PdfToolbar.tsx
@@ -24,8 +24,8 @@ const PdfToolbar: React.FC<PdfToolbarProps> = ({ wrapperRef, mapLayerRef, id }) 
       colorMode,
       bwHard: hardBW,
       bwThreshold: threshold,
-      marginsMm: 0,
-      scale: 0.5,
+      marginsMm: 5,
+      scale: pdfMode === 'onePage' ? 1 : undefined,
       orientation,
       fileName:
         (colorMode === 'bw' ? 'map-bw-' : 'map-color-') +


### PR DESCRIPTION
## Summary
- prevent map cropping by removing forced scale and allowing exportMapToPDF to auto-fit pages
- add 5mm margins for clearer output

## Testing
- `npm test` *(fails: command not found)*
- `apt-get update` *(fails: The repository ... is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_68bd4b2ae85883238dc0996f5fdf2161