### PR TITLE
Add print and center controls to map view

### DIFF
--- a/src/components/Seats/SeatsManagement.tsx
+++ b/src/components/Seats/SeatsManagement.tsx
@@ -118,7 +118,7 @@ function SeatsManagement(): JSX.Element {
   }, [currentMap, benches, seats, mapBounds, mapOffset]);
 
   const printMap = useCallback((mapId: string) => {
-    const url = `${window.location.origin}${window.location.pathname}#/view/${mapId}?print=1`;
+    const url = `${window.location.origin}${window.location.pathname}#/view/${mapId}`;
     window.open(url, '_blank');
   }, []);
 


### PR DESCRIPTION
## Summary
- add printer button directly in map view
- open map view in new tab without auto-print parameter
- add center map control to recenter seating layout

## Testing
- `npm run lint` *(fails: 9 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7dcdc5008323bb3cca56542da422