### PR TITLE
Add sticker printing for map seats

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,6 +11,7 @@ import Login from './components/Auth/Login';
 import RequireAuth from './components/Auth/RequireAuth';
 import ProfileSetup from './components/Auth/ProfileSetup';
 import MapView from './components/Seats/MapView';
+import StickerPrint from './components/Seats/StickerPrint';
 import Pricing from './components/Pricing/Pricing';
 import ProPayment from './components/Pricing/ProPayment';
 import PaymentThankYou from './components/Pricing/PaymentThankYou';
@@ -32,6 +33,14 @@ function App() {
           <Route path="/thank-you" element={<PaymentThankYou />} />
           <Route path="/payment-cancelled" element={<PaymentCancelled />} />
           <Route path="/setup" element={<RequireAuth><ProfileSetup /></RequireAuth>} />
+          <Route
+            path="/view/:id/labels"
+            element={
+              <AppProvider>
+                <StickerPrint />
+              </AppProvider>
+            }
+          />
           <Route
             path="/view/:id"
             element={

--- a/src/components/Seats/MapView.tsx
+++ b/src/components/Seats/MapView.tsx
@@ -4,15 +4,16 @@ import { useAppContext } from '../../context/AppContext';
 import { Seat, Worshiper } from '../../types';
 import { API_BASE_URL } from '../../api';
 import MapZoomControls from './MapZoomControls';
-import { Printer, Target } from 'lucide-react';
+import { Printer, Target, Tags } from 'lucide-react';
 
 const MapView: React.FC = () => {
   const { id } = useParams<{ id?: string }>();
-  const { benches, seats, loadMap, mapBounds, mapOffset, setMapOffset, worshipers } = useAppContext();
+  const { benches, seats, loadMap, mapBounds, mapOffset, setMapOffset, worshipers, currentMapId } = useAppContext();
   const navigate = useNavigate();
   const containerRef = useRef<HTMLDivElement>(null);
   const [baseSize, setBaseSize] = useState({ width: 1200, height: 800 });
   const [zoom, setZoom] = useState(1);
+  const mapId = id || currentMapId;
 
   useEffect(() => {
     const originalPadding = document.body.style.padding;
@@ -121,6 +122,13 @@ const MapView: React.FC = () => {
             aria-label="הדפס מפה"
           >
             <Printer className="h-4 w-4" />
+          </button>
+          <button
+            onClick={() => mapId && navigate(`/view/${mapId}/labels`)}
+            className="p-2 rounded-lg bg-gray-100 text-gray-600 hover:bg-gray-200 transition-colors"
+            aria-label="הדפס מדבקות"
+          >
+            <Tags className="h-4 w-4" />
           </button>
         </div>
         <div

--- a/src/components/Seats/StickerPrint.tsx
+++ b/src/components/Seats/StickerPrint.tsx
@@ -1,0 +1,66 @@
+import React, { useEffect } from 'react';
+import { useParams } from 'react-router-dom';
+import { useAppContext } from '../../context/AppContext';
+
+const StickerPrint: React.FC = () => {
+  const { id } = useParams<{ id?: string }>();
+  const { benches, seats, worshipers, loadMap } = useAppContext();
+
+  useEffect(() => {
+    if (id) {
+      loadMap(id);
+    }
+  }, [id, loadMap]);
+
+  const stickers = seats
+    .filter(s => s.userId)
+    .map(s => {
+      const w = worshipers.find(w => w.id === s.userId);
+      const bench = benches.find(b => b.id === s.benchId);
+      const name = w ? `${w.title ? w.title + ' ' : ''}${w.firstName} ${w.lastName}` : '';
+      const benchName = bench?.name || '';
+      return { name, benchName };
+    });
+
+  useEffect(() => {
+    const originalPadding = document.body.style.padding;
+    const originalMargin = document.body.style.margin;
+    document.body.style.padding = '0';
+    document.body.style.margin = '0';
+    // Trigger print after styles applied
+    if (stickers.length) {
+      setTimeout(() => window.print(), 0);
+    }
+    return () => {
+      document.body.style.padding = originalPadding;
+      document.body.style.margin = originalMargin;
+    };
+  }, [stickers]);
+
+  const pages: { name: string; benchName: string }[][] = [];
+  for (let i = 0; i < stickers.length; i += 24) {
+    pages.push(stickers.slice(i, i + 24));
+  }
+
+  return (
+    <div className="p-0 m-0">
+      {pages.map((page, pageIndex) => (
+        <div
+          key={pageIndex}
+          className="w-[210mm] h-[297mm] grid grid-cols-3 grid-rows-8"
+          style={{ pageBreakAfter: pageIndex < pages.length - 1 ? 'always' : 'auto' }}
+        >
+          {page.map((s, i) => (
+            <div key={i} className="flex flex-col items-center justify-center text-center p-2">
+              <div className="text-xs">{s.benchName}</div>
+              <div className="text-lg font-bold">{s.name}</div>
+            </div>
+          ))}
+        </div>
+      ))}
+    </div>
+  );
+};
+
+export default StickerPrint;
+


### PR DESCRIPTION
## Summary
- add dedicated page for printing 24-seat sticker sheets (3x8 grid)
- link map view to sticker printing via new route and control button

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_68bd925eb9788323ab32e0873c941de4