### PR TITLE
feat: add vertical alignment tools and prevent overlap

### DIFF
--- a/src/components/Seats/SeatsManagement.tsx
+++ b/src/components/Seats/SeatsManagement.tsx
@@ -432,40 +432,58 @@ function SeatsManagement(): JSX.Element {
     setBenches(prev=>prev.map(b=> b.id===benchId ? {...b, orientation: b.orientation==='horizontal' ? 'vertical' : 'horizontal'} : b));
   }, [setBenches]);
 
-  const alignSelectedBenches = useCallback((type: 'left' | 'right' | 'top' | 'bottom' | 'centerX' | 'centerY') => {
-    setBenches(prev => {
-      const selected = prev.filter(b => selectedBenches.includes(b.id) && !b.locked);
-      if (!selected.length) return prev;
-      let minX = Infinity, minY = Infinity, maxX = -Infinity, maxY = -Infinity;
-      selected.forEach(b => {
-        const { width, height } = benchDims(b);
-        minX = Math.min(minX, b.position.x);
-        minY = Math.min(minY, b.position.y);
-        maxX = Math.max(maxX, b.position.x + width);
-        maxY = Math.max(maxY, b.position.y + height);
+  const alignSelectedBenches = useCallback(
+    (type: 'left' | 'right' | 'top' | 'bottom' | 'centerX' | 'centerY') => {
+      setBenches(prev => {
+        const selected = prev.filter(b => selectedBenches.includes(b.id) && !b.locked);
+        if (!selected.length) return prev;
+        let minX = Infinity,
+          minY = Infinity,
+          maxX = -Infinity,
+          maxY = -Infinity;
+        selected.forEach(b => {
+          const { width, height } = benchDims(b);
+          minX = Math.min(minX, b.position.x);
+          minY = Math.min(minY, b.position.y);
+          maxX = Math.max(maxX, b.position.x + width);
+          maxY = Math.max(maxY, b.position.y + height);
+        });
+        const aligned = prev.map(b => {
+          if (!selectedBenches.includes(b.id) || b.locked) return b;
+          const { width, height } = benchDims(b);
+          switch (type) {
+            case 'left':
+              return { ...b, position: { ...b.position, x: minX } };
+            case 'right':
+              return { ...b, position: { ...b.position, x: maxX - width } };
+            case 'centerX':
+              return {
+                ...b,
+                position: { ...b.position, x: (minX + maxX) / 2 - width / 2 },
+              };
+            case 'top':
+              return { ...b, position: { ...b.position, y: minY } };
+            case 'bottom':
+              return { ...b, position: { ...b.position, y: maxY - height } };
+            case 'centerY':
+              return {
+                ...b,
+                position: { ...b.position, y: (minY + maxY) / 2 - height / 2 },
+              };
+            default:
+              return b;
+          }
+        });
+        const spacedSelected = ensureBenchSpacing(
+          aligned.filter(b => selectedBenches.includes(b.id) && !b.locked)
+        );
+        return aligned.map(b =>
+          spacedSelected.find(s => s.id === b.id) ?? b
+        );
       });
-      return prev.map(b => {
-        if (!selectedBenches.includes(b.id) || b.locked) return b;
-        const { width, height } = benchDims(b);
-        switch (type) {
-          case 'left':
-            return { ...b, position: { ...b.position, x: minX } };
-          case 'right':
-            return { ...b, position: { ...b.position, x: maxX - width } };
-          case 'centerX':
-            return { ...b, position: { ...b.position, x: (minX + maxX) / 2 - width / 2 } };
-          case 'top':
-            return { ...b, position: { ...b.position, y: minY } };
-          case 'bottom':
-            return { ...b, position: { ...b.position, y: maxY - height } };
-          case 'centerY':
-            return { ...b, position: { ...b.position, y: (minY + maxY) / 2 - height / 2 } };
-          default:
-            return b;
-        }
-      });
-    });
-  }, [selectedBenches, setBenches]);
+    },
+    [selectedBenches, setBenches]
+  );
 
   const toggleBenchLock = useCallback((benchId: string) => {
     setBenches(prev=>prev.map(b=> b.id===benchId ? {...b, locked: !b.locked} : b));

--- a/src/components/common/Align.tsx
+++ b/src/components/common/Align.tsx
@@ -1,18 +1,42 @@
 import React from 'react';
 
-export type AlignOptions = 'left' | 'center' | 'right';
+export type HorizontalAlignOptions = 'left' | 'center' | 'right';
+export type VerticalAlignOptions = 'top' | 'center' | 'bottom';
 
 interface AlignProps {
-  align?: AlignOptions;
+  /** Horizontal alignment */
+  align?: HorizontalAlignOptions;
+  /** Vertical alignment */
+  vertical?: VerticalAlignOptions;
   className?: string;
   children: React.ReactNode;
 }
 
-const Align: React.FC<AlignProps> = ({ align = 'left', className = '', children }) => {
-  const alignmentClass =
-    align === 'center' ? 'text-center' : align === 'right' ? 'text-right' : 'text-left';
+const Align: React.FC<AlignProps> = ({
+  align = 'left',
+  vertical = 'top',
+  className = '',
+  children,
+}) => {
+  const horizontalClass =
+    align === 'center'
+      ? 'text-center justify-center'
+      : align === 'right'
+      ? 'text-right justify-end'
+      : 'text-left justify-start';
 
-  return <div className={`${alignmentClass} ${className}`.trim()}>{children}</div>;
+  const verticalClass =
+    vertical === 'center'
+      ? 'items-center'
+      : vertical === 'bottom'
+      ? 'items-end'
+      : 'items-start';
+
+  return (
+    <div className={`flex flex-wrap ${horizontalClass} ${verticalClass} ${className}`.trim()}>
+      {children}
+    </div>
+  );
 };
 
 export default Align;


### PR DESCRIPTION
## Summary
- extend `Align` component with vertical alignment and flex wrap to avoid overlaps
- ensure aligned benches maintain spacing after alignment

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bda376a0bc832392ebd730fad06e49