### PR TITLE
Add rectangular boundary tool with zone marking

### DIFF
--- a/src/components/Seats/MapView.tsx
+++ b/src/components/Seats/MapView.tsx
@@ -61,6 +61,9 @@ const MapView: React.FC = () => {
       const worshiper = getWorshiperById(seat.userId);
       return { worshiper, color: 'bg-blue-500' };
     }
+    if (seat.area === 2) {
+      return { worshiper: null, color: 'bg-red-300' };
+    }
     return { worshiper: null, color: 'bg-gray-300' };
   };
 
@@ -203,7 +206,7 @@ const MapView: React.FC = () => {
             {/* Boundaries */}
             <svg className="absolute inset-0 pointer-events-none">
               {boundaries.map(b => (
-                <line key={b.id} x1={b.start.x + mapBounds.left} y1={b.start.y + mapBounds.top} x2={b.end.x + mapBounds.left} y2={b.end.y + mapBounds.top} stroke="#ff0000" strokeWidth={2} />
+                <rect key={b.id} x={b.x + mapBounds.left} y={b.y + mapBounds.top} width={b.width} height={b.height} stroke="#ff0000" fill="none" strokeWidth={2} />
               ))}
             </svg>
           </div>

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -380,8 +380,8 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
 
     const adjustedBoundaries = shiftX || shiftY ? boundaries.map(b => ({
       ...b,
-      start: { x: b.start.x - shiftX, y: b.start.y - shiftY },
-      end: { x: b.end.x - shiftX, y: b.end.y - shiftY },
+      x: b.x - shiftX,
+      y: b.y - shiftY,
     })) : boundaries;
 
     const maxXShifted = maxX - shiftX;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -34,6 +34,7 @@ export interface Seat {
     y: number;
   };
   isOccupied: boolean;
+  area?: number;
 }
 
 export interface Bench {
@@ -81,8 +82,10 @@ export interface MapOffset {
 
 export interface Boundary {
   id: string;
-  start: { x: number; y: number };
-  end: { x: number; y: number };
+  x: number;
+  y: number;
+  width: number;
+  height: number;
 }
 
 export interface Sticker {


### PR DESCRIPTION
## Summary
- add `area` support to seats and redefine boundaries as rectangles
- allow drawing rectangular boundaries that mark enclosed seats as zone 2
- render boundaries and zone 2 seats in red for management and view modes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js'; install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_68bdb58ff6ec8323b7b3daa1f2c0524f