### PR TITLE
feat: add item actions and default place charge

### DIFF
--- a/src/components/Worshipers/WorshiperCard.tsx
+++ b/src/components/Worshipers/WorshiperCard.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import { X, Phone, Mail, MapPin, User as UserIcon, Users } from 'lucide-react';
 import { Worshiper, WorshiperItem } from '../../types';
+import WorshiperItemsForm from './WorshiperItemsForm';
 
 interface Props {
   worshiper: Worshiper;
@@ -9,6 +10,7 @@ interface Props {
 
 const WorshiperCard: React.FC<Props> = ({ worshiper, onClose }) => {
   const [activeTab, setActiveTab] = useState<'promises' | 'aliyot' | 'places'>('promises');
+  const [editingField, setEditingField] = useState<null | 'promises' | 'aliyot' | 'places'>(null);
 
   const renderItems = (items?: WorshiperItem[]) => {
     if (!items || items.length === 0) {
@@ -114,7 +116,46 @@ const WorshiperCard: React.FC<Props> = ({ worshiper, onClose }) => {
             ))}
           </div>
           {renderItems(tabs.find(t => t.key === activeTab)?.items)}
+          {activeTab === 'places' && worshiper.places && worshiper.places.length > 1 && (
+            <div className="text-right font-semibold mt-2">
+              סה"כ: {worshiper.places.reduce((sum, i) => sum + i.amount, 0)}
+            </div>
+          )}
+          <div className="flex justify-end space-x-2 space-x-reverse mt-4">
+            <button
+              onClick={() => setEditingField('promises')}
+              className="px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700"
+            >
+              הוסף התחייבות חדש
+            </button>
+            <button
+              onClick={() => setEditingField('aliyot')}
+              className="px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700"
+            >
+              הוסף עליה חדשה
+            </button>
+            <button
+              onClick={() => setEditingField('places')}
+              className="px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700"
+            >
+              הוסף חיוב מקומות חדשה
+            </button>
+          </div>
         </div>
+        {editingField && (
+          <WorshiperItemsForm
+            worshiper={worshiper}
+            field={editingField}
+            title={
+              editingField === 'promises'
+                ? 'הבטחות'
+                : editingField === 'aliyot'
+                  ? 'עליות'
+                  : 'מקומות'
+            }
+            onClose={() => setEditingField(null)}
+          />
+        )}
       </div>
     </div>
   );

--- a/src/components/Worshipers/WorshiperItemsForm.tsx
+++ b/src/components/Worshipers/WorshiperItemsForm.tsx
@@ -12,9 +12,23 @@ interface Props {
 
 const WorshiperItemsForm: React.FC<Props> = ({ worshiper, field, title, onClose }) => {
   const { setWorshipers } = useAppContext();
-  const [items, setItems] = useState<WorshiperItem[]>(worshiper[field] || []);
+  const [items, setItems] = useState<WorshiperItem[]>(() => {
+    if (field === 'places' && (!worshiper.places || worshiper.places.length === 0)) {
+      return [
+        {
+          id: Date.now().toString(),
+          description: 'מקום 1',
+          amount: 0,
+          paid: false,
+          createdAtGregorian: '',
+          createdAtHebrew: '',
+        },
+      ];
+    }
+    return worshiper[field] || [];
+  });
   const [newItem, setNewItem] = useState<Partial<WorshiperItem>>({
-    description: '',
+    description: field === 'places' ? `מקום ${items.length + 1}` : '',
     amount: 0,
     paid: false,
     createdAtGregorian: '',
@@ -23,6 +37,7 @@ const WorshiperItemsForm: React.FC<Props> = ({ worshiper, field, title, onClose 
 
   const addItem = () => {
     if (!newItem.description) return;
+    const nextIndex = items.length + 1;
     const item: WorshiperItem = {
       id: Date.now().toString(),
       description: newItem.description!,
@@ -33,7 +48,7 @@ const WorshiperItemsForm: React.FC<Props> = ({ worshiper, field, title, onClose 
     };
     setItems(prev => [...prev, item]);
     setNewItem({
-      description: '',
+      description: field === 'places' ? `מקום ${nextIndex + 1}` : '',
       amount: 0,
       paid: false,
       createdAtGregorian: '',


### PR DESCRIPTION
## Summary
- add action buttons on worshiper card for commitments, aliyot, and place charges
- default place 1 charge and auto-incrementing labels when adding new places
- show total charges when a worshiper has multiple places

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm ci` *(fails: 403 Forbidden - GET https://registry.npmjs.org/html2canvas)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc1353b148323bae447b5f7f1320d