### PR TITLE
Highlight boundary regions on maps

### DIFF
--- a/src/components/Seats/MapView.tsx
+++ b/src/components/Seats/MapView.tsx
@@ -9,7 +9,17 @@ import { Printer, Target, Tags } from 'lucide-react';
 const MapView: React.FC = () => {
   const { id } = useParams<{ id?: string }>();
 
-  const { benches, seats, loadMap, mapBounds, mapOffset, setMapOffset, worshipers, currentMapId } = useAppContext();
+  const {
+    benches,
+    seats,
+    loadMap,
+    mapBounds,
+    mapOffset,
+    setMapOffset,
+    worshipers,
+    currentMapId,
+    boundaries,
+  } = useAppContext();
   const navigate = useNavigate();
   const containerRef = useRef<HTMLDivElement>(null);
   const [baseSize, setBaseSize] = useState({ width: 1200, height: 800 });
@@ -206,7 +216,17 @@ const MapView: React.FC = () => {
             {/* Boundaries */}
             <svg className="absolute inset-0 pointer-events-none">
               {boundaries.map(b => (
-                <rect key={b.id} x={b.x + mapBounds.left} y={b.y + mapBounds.top} width={b.width} height={b.height} stroke="#ff0000" fill="none" strokeWidth={2} />
+                <rect
+                  key={b.id}
+                  x={b.x + mapBounds.left}
+                  y={b.y + mapBounds.top}
+                  width={b.width}
+                  height={b.height}
+                  stroke="#ff0000"
+                  strokeWidth={2}
+                  fill="#ff0000"
+                  fillOpacity={0.2}
+                />
               ))}
             </svg>
           </div>

--- a/src/components/Seats/SeatsManagement.tsx
+++ b/src/components/Seats/SeatsManagement.tsx
@@ -991,10 +991,30 @@ function SeatsManagement(): JSX.Element {
               {/* Boundaries */}
               <svg className="absolute inset-0 pointer-events-none">
                 {boundaries.map(b => (
-                  <rect key={b.id} x={b.x + mapBounds.left} y={b.y + mapBounds.top} width={b.width} height={b.height} stroke="#ff0000" fill="none" strokeWidth={2} />
+                  <rect
+                    key={b.id}
+                    x={b.x + mapBounds.left}
+                    y={b.y + mapBounds.top}
+                    width={b.width}
+                    height={b.height}
+                    stroke="#ff0000"
+                    strokeWidth={2}
+                    fill="#ff0000"
+                    fillOpacity={0.2}
+                  />
                 ))}
                 {drawingBoundary && (
-                  <rect x={drawingBoundary.x + mapBounds.left} y={drawingBoundary.y + mapBounds.top} width={drawingBoundary.width} height={drawingBoundary.height} stroke="#ff0000" strokeWidth={2} fill="none" strokeDasharray="4 2" />
+                  <rect
+                    x={drawingBoundary.x + mapBounds.left}
+                    y={drawingBoundary.y + mapBounds.top}
+                    width={drawingBoundary.width}
+                    height={drawingBoundary.height}
+                    stroke="#ff0000"
+                    strokeWidth={2}
+                    fill="#ff0000"
+                    fillOpacity={0.1}
+                    strokeDasharray="4 2"
+                  />
                 )}
               </svg>
 


### PR DESCRIPTION
## Summary
- Fill boundary rectangles with a translucent color so the entire enclosed area is emphasized
- Include boundaries in MapView and render them with the same translucent highlight

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/html2canvas)*
- `npm run build` *(fails: vite: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bdc889806c8323abfd9223839ab48e