### PR TITLE
feat: track seats via worshiper places

### DIFF
--- a/src/components/Seats/SeatsManagement.tsx
+++ b/src/components/Seats/SeatsManagement.tsx
@@ -1127,7 +1127,8 @@ function SeatsManagement(): JSX.Element {
               >פנה מקום</button>
               {worshipers.map(w => {
                 const assignedSeats = seats.filter(s => s.userId === w.id).length;
-                const isFull = assignedSeats + selectedSeatsForWorshiper.length > w.seatCount;
+                const seatCount = w.places?.reduce((sum, i) => sum + i.amount, 0) ?? 0;
+                const isFull = assignedSeats + selectedSeatsForWorshiper.length > seatCount;
                 return (
                   <button
                     key={w.id}

--- a/src/components/Worshipers/WorshiperCard.tsx
+++ b/src/components/Worshipers/WorshiperCard.tsx
@@ -11,6 +11,7 @@ interface Props {
 const WorshiperCard: React.FC<Props> = ({ worshiper, onClose }) => {
   const [activeTab, setActiveTab] = useState<'promises' | 'aliyot' | 'places'>('promises');
   const [editingField, setEditingField] = useState<null | 'promises' | 'aliyot' | 'places'>(null);
+  const totalSeats = worshiper.places?.reduce((sum, i) => sum + i.amount, 0) ?? 0;
 
   const renderItems = (items?: WorshiperItem[]) => {
     if (!items || items.length === 0) {
@@ -95,7 +96,7 @@ const WorshiperCard: React.FC<Props> = ({ worshiper, onClose }) => {
           )}
           <div className="flex items-center">
             <Users className="h-4 w-4 ml-2 text-gray-500" />
-            <span>כמות מקומות: {worshiper.seatCount}</span>
+            <span>כמות מקומות: {totalSeats}</span>
           </div>
         </div>
 

--- a/src/components/Worshipers/WorshiperManagement.tsx
+++ b/src/components/Worshipers/WorshiperManagement.tsx
@@ -24,7 +24,6 @@ const WorshiperManagement: React.FC = () => {
     phone: '',
     secondaryPhone: '',
     email: '',
-    seatCount: 1,
     promises: [],
     aliyot: [],
     places: [],
@@ -48,6 +47,17 @@ const WorshiperManagement: React.FC = () => {
         headers.forEach((h, i) => {
           obj[h] = values[i]?.trim() || '';
         });
+        const seatCount = Number(obj['כמות מקומות'] || 0);
+        const places = seatCount
+          ? [{
+              id: (Date.now() + index).toString(),
+              description: 'מקום',
+              amount: seatCount,
+              paid: false,
+              createdAtGregorian: '',
+              createdAtHebrew: '',
+            }]
+          : [];
         return {
           id: Date.now().toString() + index,
           title: obj['תואר'] || '',
@@ -58,7 +68,7 @@ const WorshiperManagement: React.FC = () => {
           phone: obj['טלפון'] || '',
           secondaryPhone: obj['טלפון נוסף'] || '',
           email: obj['אימייל'] || '',
-          seatCount: Number(obj['כמות מקומות'] || 1),
+          places,
         } as Worshiper;
       });
       setWorshipers(prev => [...prev, ...imported]);
@@ -99,7 +109,6 @@ const WorshiperManagement: React.FC = () => {
         phone: formData.phone || '',
         secondaryPhone: formData.secondaryPhone || '',
         email: formData.email || '',
-        seatCount: formData.seatCount || 1,
         promises: formData.promises || [],
         aliyot: formData.aliyot || [],
         places: formData.places || [],
@@ -117,7 +126,6 @@ const WorshiperManagement: React.FC = () => {
       phone: '',
       secondaryPhone: '',
       email: '',
-      seatCount: 1,
       promises: [],
       aliyot: [],
       places: [],
@@ -148,7 +156,6 @@ const WorshiperManagement: React.FC = () => {
       phone: '',
       secondaryPhone: '',
       email: '',
-      seatCount: 1,
       promises: [],
       aliyot: [],
       places: [],
@@ -167,7 +174,6 @@ const WorshiperManagement: React.FC = () => {
       phone: '',
       secondaryPhone: '',
       email: '',
-      seatCount: 1,
       promises: [],
       aliyot: [],
       places: [],
@@ -307,16 +313,6 @@ const WorshiperManagement: React.FC = () => {
               />
             </div>
 
-            <div>
-              <label className="block text-sm font-medium text-gray-700 mb-2">כמות מקומות</label>
-              <input
-                type="number"
-                min="1"
-                value={formData.seatCount || 1}
-                onChange={(e) => setFormData(prev => ({ ...prev, seatCount: Number(e.target.value) }))}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-blue-500 focus:border-blue-500"
-              />
-            </div>
           </div>
 
           <div className="flex space-x-3 space-x-reverse">
@@ -372,7 +368,7 @@ const WorshiperManagement: React.FC = () => {
                   <td className="px-4 py-2">{w.secondaryPhone}</td>
                   <td className="px-4 py-2">{w.address}</td>
                   <td className="px-4 py-2">{w.city}</td>
-                  <td className="px-4 py-2 text-center">{w.seatCount}</td>
+                  <td className="px-4 py-2 text-center">{w.places?.reduce((sum, i) => sum + i.amount, 0) ?? 0}</td>
                   <td className="px-4 py-2">
                     <div className="flex space-x-2 space-x-reverse">
                       <button

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -230,7 +230,16 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
       city: 'תל אביב',
       phone: '050-1234567',
       email: 'yossi@example.com',
-      seatCount: 1,
+      places: [
+        {
+          id: 'p1',
+          description: 'מקום',
+          amount: 1,
+          paid: false,
+          createdAtGregorian: '',
+          createdAtHebrew: '',
+        },
+      ],
     },
     {
       id: '2',
@@ -241,7 +250,16 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
       city: 'ירושלים',
       phone: '052-9876543',
       email: 'dana@example.com',
-      seatCount: 2,
+      places: [
+        {
+          id: 'p2',
+          description: 'מקום',
+          amount: 2,
+          paid: false,
+          createdAtGregorian: '',
+          createdAtHebrew: '',
+        },
+      ],
     },
     {
       id: '3',
@@ -252,7 +270,16 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
       city: 'חיפה',
       phone: '054-5555555',
       email: 'michael@example.com',
-      seatCount: 1,
+      places: [
+        {
+          id: 'p3',
+          description: 'מקום',
+          amount: 1,
+          paid: false,
+          createdAtGregorian: '',
+          createdAtHebrew: '',
+        },
+      ],
     },
     {
       id: '4',
@@ -263,7 +290,16 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
       city: 'באר שבע',
       phone: '053-1111111',
       email: 'sarah@example.com',
-      seatCount: 3,
+      places: [
+        {
+          id: 'p4',
+          description: 'מקום',
+          amount: 3,
+          paid: false,
+          createdAtGregorian: '',
+          createdAtHebrew: '',
+        },
+      ],
     },
     {
       id: '5',
@@ -274,7 +310,16 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
       city: 'נתניה',
       phone: '052-2222222',
       email: 'avi@example.com',
-      seatCount: 1,
+      places: [
+        {
+          id: 'p5',
+          description: 'מקום',
+          amount: 1,
+          paid: false,
+          createdAtGregorian: '',
+          createdAtHebrew: '',
+        },
+      ],
     },
   ], userKey);
   const initialBenches = generateInitialBenches();

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -9,7 +9,6 @@ export interface Worshiper {
   phone: string;
   secondaryPhone?: string;
   email: string;
-  seatCount: number;
   avatar?: string;
   promises?: WorshiperItem[];
   aliyot?: WorshiperItem[];


### PR DESCRIPTION
## Summary
- remove `seatCount` from worshiper type and store seats as place entries
- derive seat totals from place entries across UI and seat assignment logic

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68bdcedd80848323a07e9cacb59aa1f7