### PR TITLE
Separate seat quantity and pricing fields

### DIFF
--- a/src/components/Seats/SeatsManagement.tsx
+++ b/src/components/Seats/SeatsManagement.tsx
@@ -1147,7 +1147,7 @@ function SeatsManagement(): JSX.Element {
               >פנה מקום</button>
               {worshipers.map(w => {
                 const assignedSeats = seats.filter(s => s.userId === w.id).length;
-                const seatCount = w.places?.reduce((sum, i) => sum + i.amount, 0) ?? 0;
+                const seatCount = w.places?.reduce((sum, i) => sum + (i.count ?? 0), 0) ?? 0;
                 const isFull = assignedSeats + selectedSeatsForWorshiper.length > seatCount;
                 return (
                   <button

--- a/src/components/Worshipers/WorshiperCard.tsx
+++ b/src/components/Worshipers/WorshiperCard.tsx
@@ -11,9 +11,12 @@ interface Props {
 const WorshiperCard: React.FC<Props> = ({ worshiper, onClose }) => {
   const [activeTab, setActiveTab] = useState<'promises' | 'aliyot' | 'places'>('promises');
   const [editingField, setEditingField] = useState<null | 'promises' | 'aliyot' | 'places'>(null);
-  const totalSeats = worshiper.places?.reduce((sum, i) => sum + i.amount, 0) ?? 0;
+  const totalSeats = worshiper.places?.reduce((sum, i) => sum + (i.count ?? 0), 0) ?? 0;
 
-  const renderItems = (items?: WorshiperItem[]) => {
+  const renderItems = (
+    field: 'promises' | 'aliyot' | 'places',
+    items?: WorshiperItem[]
+  ) => {
     if (!items || items.length === 0) {
       return <p className="text-center text-gray-500 text-sm">אין פריטים</p>;
     }
@@ -23,7 +26,15 @@ const WorshiperCard: React.FC<Props> = ({ worshiper, onClose }) => {
           <thead>
             <tr className="text-right">
               <th className="px-2 py-1">תיאור</th>
-              <th className="px-2 py-1">סכום</th>
+              {field === 'places' ? (
+                <>
+                  <th className="px-2 py-1">סכום למקום</th>
+                  <th className="px-2 py-1">מספר מקומות</th>
+                  <th className="px-2 py-1">סה"כ</th>
+                </>
+              ) : (
+                <th className="px-2 py-1">סכום</th>
+              )}
               <th className="px-2 py-1">שולם</th>
               <th className="px-2 py-1">תאריך לועזי</th>
               <th className="px-2 py-1">תאריך עברי</th>
@@ -33,7 +44,15 @@ const WorshiperCard: React.FC<Props> = ({ worshiper, onClose }) => {
             {items.map(i => (
               <tr key={i.id} className="border-t">
                 <td className="px-2 py-1">{i.description}</td>
-                <td className="px-2 py-1 text-center">{i.amount}</td>
+                {field === 'places' ? (
+                  <>
+                    <td className="px-2 py-1 text-center">{i.amount}</td>
+                    <td className="px-2 py-1 text-center">{i.count ?? 0}</td>
+                    <td className="px-2 py-1 text-center">{(i.amount || 0) * (i.count ?? 0)}</td>
+                  </>
+                ) : (
+                  <td className="px-2 py-1 text-center">{i.amount}</td>
+                )}
                 <td className="px-2 py-1 text-center">{i.paid ? 'כן' : 'לא'}</td>
                 <td className="px-2 py-1">{i.createdAtGregorian}</td>
                 <td className="px-2 py-1">{i.createdAtHebrew}</td>
@@ -116,10 +135,13 @@ const WorshiperCard: React.FC<Props> = ({ worshiper, onClose }) => {
               </button>
             ))}
           </div>
-          {renderItems(tabs.find(t => t.key === activeTab)?.items)}
+          {renderItems(
+            activeTab,
+            tabs.find(t => t.key === activeTab)?.items
+          )}
           {activeTab === 'places' && worshiper.places && worshiper.places.length > 1 && (
             <div className="text-right font-semibold mt-2">
-              סה"כ: {worshiper.places.reduce((sum, i) => sum + i.amount, 0)}
+              סה"כ: {worshiper.places.reduce((sum, i) => sum + (i.amount || 0) * (i.count ?? 0), 0)}
             </div>
           )}
           <div className="flex justify-end space-x-2 space-x-reverse mt-4">

--- a/src/components/Worshipers/WorshiperItemsForm.tsx
+++ b/src/components/Worshipers/WorshiperItemsForm.tsx
@@ -17,8 +17,9 @@ const WorshiperItemsForm: React.FC<Props> = ({ worshiper, field, title, onClose 
       return [
         {
           id: Date.now().toString(),
-          description: 'מקום 1',
+          description: 'מקומות בבית הכנסת',
           amount: 0,
+          count: 1,
           paid: false,
           createdAtGregorian: '',
           createdAtHebrew: '',
@@ -27,9 +28,13 @@ const WorshiperItemsForm: React.FC<Props> = ({ worshiper, field, title, onClose 
     }
     return worshiper[field] || [];
   });
+  const [descriptionOption, setDescriptionOption] = useState(
+    field === 'places' ? 'מקומות בבית הכנסת' : ''
+  );
   const [newItem, setNewItem] = useState<Partial<WorshiperItem>>({
-    description: field === 'places' ? `מקום ${items.length + 1}` : '',
+    description: field === 'places' ? 'מקומות בבית הכנסת' : '',
     amount: 0,
+    count: field === 'places' ? 1 : undefined,
     paid: false,
     createdAtGregorian: '',
     createdAtHebrew: '',
@@ -42,18 +47,21 @@ const WorshiperItemsForm: React.FC<Props> = ({ worshiper, field, title, onClose 
       id: Date.now().toString(),
       description: newItem.description!,
       amount: Number(newItem.amount) || 0,
+      count: field === 'places' ? Number(newItem.count) || 0 : undefined,
       paid: !!newItem.paid,
       createdAtGregorian: newItem.createdAtGregorian || '',
       createdAtHebrew: newItem.createdAtHebrew || '',
     };
     setItems(prev => [...prev, item]);
     setNewItem({
-      description: field === 'places' ? `מקום ${nextIndex + 1}` : '',
+      description: field === 'places' ? 'מקומות בבית הכנסת' : '',
       amount: 0,
+      count: field === 'places' ? 1 : undefined,
       paid: false,
       createdAtGregorian: '',
       createdAtHebrew: '',
     });
+    setDescriptionOption(field === 'places' ? 'מקומות בבית הכנסת' : '');
   };
 
   const removeItem = (id: string) => {
@@ -84,7 +92,15 @@ const WorshiperItemsForm: React.FC<Props> = ({ worshiper, field, title, onClose 
             <thead>
               <tr className="text-right">
                 <th className="px-2 py-1">תיאור</th>
-                <th className="px-2 py-1">סכום</th>
+                {field === 'places' ? (
+                  <>
+                    <th className="px-2 py-1">סכום למקום</th>
+                    <th className="px-2 py-1">מספר מקומות</th>
+                    <th className="px-2 py-1">סה"כ</th>
+                  </>
+                ) : (
+                  <th className="px-2 py-1">סכום</th>
+                )}
                 <th className="px-2 py-1">שולם</th>
                 <th className="px-2 py-1">תאריך לועזי</th>
                 <th className="px-2 py-1">תאריך עברי</th>
@@ -95,7 +111,15 @@ const WorshiperItemsForm: React.FC<Props> = ({ worshiper, field, title, onClose 
               {items.map(i => (
                 <tr key={i.id} className="border-t">
                   <td className="px-2 py-1">{i.description}</td>
-                  <td className="px-2 py-1 text-center">{i.amount}</td>
+                  {field === 'places' ? (
+                    <>
+                      <td className="px-2 py-1 text-center">{i.amount}</td>
+                      <td className="px-2 py-1 text-center">{i.count ?? 0}</td>
+                      <td className="px-2 py-1 text-center">{(i.amount || 0) * (i.count ?? 0)}</td>
+                    </>
+                  ) : (
+                    <td className="px-2 py-1 text-center">{i.amount}</td>
+                  )}
                   <td className="px-2 py-1 text-center">{i.paid ? 'כן' : 'לא'}</td>
                   <td className="px-2 py-1">{i.createdAtGregorian}</td>
                   <td className="px-2 py-1">{i.createdAtHebrew}</td>
@@ -114,18 +138,44 @@ const WorshiperItemsForm: React.FC<Props> = ({ worshiper, field, title, onClose 
           </table>
         )}
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mb-4 text-sm">
+        <div className={`grid grid-cols-1 ${field === 'places' ? 'md:grid-cols-3' : 'md:grid-cols-2'} gap-4 mb-4 text-sm`}>
           <div>
             <label className="block mb-1">תיאור</label>
-            <input
-              type="text"
-              value={newItem.description || ''}
-              onChange={e => setNewItem(prev => ({ ...prev, description: e.target.value }))}
-              className="w-full px-2 py-1 border rounded"
-            />
+            {field === 'places' ? (
+              <>
+                <select
+                  value={descriptionOption}
+                  onChange={e => {
+                    const val = e.target.value;
+                    setDescriptionOption(val);
+                    setNewItem(prev => ({ ...prev, description: val === 'other' ? '' : val }));
+                  }}
+                  className="w-full px-2 py-1 border rounded"
+                >
+                  <option value="מקומות בבית הכנסת">מקומות בבית הכנסת</option>
+                  <option value="מקומות בעזרת נשים">מקומות בעזרת נשים</option>
+                  <option value="other">אחר</option>
+                </select>
+                {descriptionOption === 'other' && (
+                  <input
+                    type="text"
+                    value={newItem.description || ''}
+                    onChange={e => setNewItem(prev => ({ ...prev, description: e.target.value }))}
+                    className="w-full mt-2 px-2 py-1 border rounded"
+                  />
+                )}
+              </>
+            ) : (
+              <input
+                type="text"
+                value={newItem.description || ''}
+                onChange={e => setNewItem(prev => ({ ...prev, description: e.target.value }))}
+                className="w-full px-2 py-1 border rounded"
+              />
+            )}
           </div>
           <div>
-            <label className="block mb-1">סכום</label>
+            <label className="block mb-1">{field === 'places' ? 'סכום למקום' : 'סכום'}</label>
             <input
               type="number"
               value={newItem.amount || 0}
@@ -133,6 +183,17 @@ const WorshiperItemsForm: React.FC<Props> = ({ worshiper, field, title, onClose 
               className="w-full px-2 py-1 border rounded"
             />
           </div>
+          {field === 'places' && (
+            <div>
+              <label className="block mb-1">מספר מקומות</label>
+              <input
+                type="number"
+                value={newItem.count || 0}
+                onChange={e => setNewItem(prev => ({ ...prev, count: Number(e.target.value) }))}
+                className="w-full px-2 py-1 border rounded"
+              />
+            </div>
+          )}
           <div className="flex items-center space-x-2 space-x-reverse">
             <input
               type="checkbox"

--- a/src/components/Worshipers/WorshiperManagement.tsx
+++ b/src/components/Worshipers/WorshiperManagement.tsx
@@ -51,8 +51,9 @@ const WorshiperManagement: React.FC = () => {
         const places = seatCount
           ? [{
               id: (Date.now() + index).toString(),
-              description: 'מקום',
-              amount: seatCount,
+              description: 'מקומות בבית הכנסת',
+              amount: 0,
+              count: seatCount,
               paid: false,
               createdAtGregorian: '',
               createdAtHebrew: '',
@@ -368,7 +369,7 @@ const WorshiperManagement: React.FC = () => {
                   <td className="px-4 py-2">{w.secondaryPhone}</td>
                   <td className="px-4 py-2">{w.address}</td>
                   <td className="px-4 py-2">{w.city}</td>
-                  <td className="px-4 py-2 text-center">{w.places?.reduce((sum, i) => sum + i.amount, 0) ?? 0}</td>
+                  <td className="px-4 py-2 text-center">{w.places?.reduce((sum, i) => sum + (i.count ?? 0), 0) ?? 0}</td>
                   <td className="px-4 py-2">
                     <div className="flex space-x-2 space-x-reverse">
                       <button

--- a/src/context/AppContext.tsx
+++ b/src/context/AppContext.tsx
@@ -233,8 +233,9 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
       places: [
         {
           id: 'p1',
-          description: 'מקום',
-          amount: 1,
+          description: 'מקומות בבית הכנסת',
+          amount: 0,
+          count: 1,
           paid: false,
           createdAtGregorian: '',
           createdAtHebrew: '',
@@ -253,8 +254,9 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
       places: [
         {
           id: 'p2',
-          description: 'מקום',
-          amount: 2,
+          description: 'מקומות בבית הכנסת',
+          amount: 0,
+          count: 2,
           paid: false,
           createdAtGregorian: '',
           createdAtHebrew: '',
@@ -273,8 +275,9 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
       places: [
         {
           id: 'p3',
-          description: 'מקום',
-          amount: 1,
+          description: 'מקומות בבית הכנסת',
+          amount: 0,
+          count: 1,
           paid: false,
           createdAtGregorian: '',
           createdAtHebrew: '',
@@ -293,8 +296,9 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
       places: [
         {
           id: 'p4',
-          description: 'מקום',
-          amount: 3,
+          description: 'מקומות בבית הכנסת',
+          amount: 0,
+          count: 3,
           paid: false,
           createdAtGregorian: '',
           createdAtHebrew: '',
@@ -313,8 +317,9 @@ export const AppProvider: React.FC<{ children: ReactNode }> = ({ children }) => 
       places: [
         {
           id: 'p5',
-          description: 'מקום',
-          amount: 1,
+          description: 'מקומות בבית הכנסת',
+          amount: 0,
+          count: 1,
           paid: false,
           createdAtGregorian: '',
           createdAtHebrew: '',

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -19,6 +19,7 @@ export interface WorshiperItem {
   id: string;
   description: string;
   amount: number;
+  count?: number;
   paid: boolean;
   createdAtGregorian: string;
   createdAtHebrew: string;


### PR DESCRIPTION
## Summary
- track seat quantity separately from per-seat price
- add predefined seat type dropdown with custom option
- adjust management logic to use new count field

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/html2canvas)*

------
https://chatgpt.com/codex/tasks/task_e_68bdd27280cc83239909f14abc1f85c3