### PR TITLE
Add exit button and auto-refresh for worshiper card

### DIFF
--- a/src/components/Worshipers/WorshiperCard.tsx
+++ b/src/components/Worshipers/WorshiperCard.tsx
@@ -163,6 +163,12 @@ const WorshiperCard: React.FC<Props> = ({ worshiper, onClose }) => {
             >
               הוסף חיוב מקומות חדשה
             </button>
+            <button
+              onClick={onClose}
+              className="px-3 py-1 bg-gray-200 text-gray-700 rounded hover:bg-gray-300"
+            >
+              צא
+            </button>
           </div>
         </div>
         {editingField && (

--- a/src/components/Worshipers/WorshiperManagement.tsx
+++ b/src/components/Worshipers/WorshiperManagement.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useRef } from 'react';
+import React, { useState, useRef, useEffect } from 'react';
 import { Worshiper } from '../../types';
 import { useAppContext } from '../../context/AppContext';
 import { Plus, Edit2, Trash2, Save, X, User as UserIcon, Upload, Download, MapPin, FileText, ArrowUp, CreditCard } from 'lucide-react';
@@ -30,6 +30,15 @@ const WorshiperManagement: React.FC = () => {
   });
 
   const fileInputRef = useRef<HTMLInputElement>(null);
+
+  useEffect(() => {
+    if (viewWorshiper) {
+      const updated = worshipers.find(w => w.id === viewWorshiper.id);
+      if (updated && updated !== viewWorshiper) {
+        setViewWorshiper(updated);
+      }
+    }
+  }, [worshipers, viewWorshiper]);
 
   const handleCsvUpload = (e: React.ChangeEvent<HTMLInputElement>) => {
     const file = e.target.files?.[0];


### PR DESCRIPTION
## Summary
- Add an explicit "צא" button to the worshiper card for closing the view
- Keep an open worshiper card in sync by refreshing when the underlying worshiper data changes

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js'; dependency installation blocked)*


------
https://chatgpt.com/codex/tasks/task_e_68bdd71028cc83238a7f001e449bafe2