### PR TITLE
Add email instructions to demo modal

### DIFF
--- a/src/components/common/DemoRequestModal.tsx
+++ b/src/components/common/DemoRequestModal.tsx
@@ -73,6 +73,9 @@ const DemoRequestModal: React.FC<DemoRequestModalProps> = ({ isOpen, onClose }) 
           </div>
         ) : (
           <form onSubmit={handleSubmit} className="space-y-4">
+            <p className="text-center text-gray-700">
+              הכניסו את כתובת המייל שלכם, ונשלח אליכם במייל פרטי חשבון ה-דמו שלכם
+            </p>
             <label className="block">
               <span className="text-gray-700">כתובת מייל</span>
               <input


### PR DESCRIPTION
## Summary
- prompt users with instructions to enter email for demo account details

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68bddfc309708323bc57a059fafc6cde