### PR TITLE
Upgrade account role after credit card payment

### DIFF
--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -17,7 +17,33 @@ export default function registerUserRoutes(app) {
       res.status(500).json({ error: 'DB error' });
     }
   });
-  
+
+  app.get('/api/users/:email', async (req, res) => {
+    try {
+      const { rows } = await query(
+        `SELECT
+          email,
+          gabbai_name AS "gabbaiName",
+          phone,
+          synagogue_name AS "synagogueName",
+          address,
+          city,
+          contact_phone AS "contactPhone",
+          role
+        FROM users
+        WHERE email = $1`,
+        [req.params.email]
+      );
+      if (!rows.length) {
+        return res.sendStatus(404);
+      }
+      res.json(rows[0]);
+    } catch (err) {
+      console.error('get user error:', err);
+      res.status(500).json({ error: 'DB error' });
+    }
+  });
+
   app.get('/api/users', async (req, res) => {
     try {
       const { rows } = await query(`

--- a/src/components/Pricing/PaymentThankYou.tsx
+++ b/src/components/Pricing/PaymentThankYou.tsx
@@ -1,9 +1,29 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { useSearchParams } from 'react-router-dom';
+import { useAuth } from '../../context/AuthContext';
+import { API_BASE_URL } from '../../api';
 
 export default function PaymentThankYou() {
   const [params] = useSearchParams();
   const orderId = params.get('orderId');
+  const { user, updateUser } = useAuth();
+
+  useEffect(() => {
+    const refreshRole = async () => {
+      if (!user?.email) return;
+      try {
+        const res = await fetch(`${API_BASE_URL}/api/users/${encodeURIComponent(user.email)}`);
+        if (!res.ok) return;
+        const data = await res.json();
+        if (data?.role && data.role !== user.role) {
+          updateUser({ role: data.role });
+        }
+      } catch (err) {
+        console.error('Failed to refresh user role', err);
+      }
+    };
+    refreshRole();
+  }, [user, updateUser]);
 
   return (
     <div className="mx-auto max-w-md p-4" dir="rtl">


### PR DESCRIPTION
## Summary
- add API endpoint to fetch a single user
- refresh current user role after payment success page

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*


------
https://chatgpt.com/codex/tasks/task_e_68be9aa2c1788323b25ff123d6f71b91