### PR TITLE
Use Ctrl key for multi-selection

### DIFF
--- a/src/components/Seats/SeatsManagement.tsx
+++ b/src/components/Seats/SeatsManagement.tsx
@@ -218,7 +218,7 @@ function SeatsManagement(): JSX.Element {
   const handleBenchClick = useCallback((benchId: string, e: React.MouseEvent) => {
     e.stopPropagation();
     setCtxMenu(s=>({...s, show:false}));
-    if (activeTool==='multiSelect' || e.shiftKey) {
+    if (activeTool==='multiSelect' || e.ctrlKey) {
       setSelectedBenches(prev => prev.includes(benchId) ? prev.filter(id=>id!==benchId) : [...prev, benchId]);
     } else {
       setSelectedBenches([benchId]);
@@ -975,7 +975,7 @@ function SeatsManagement(): JSX.Element {
                               if (e.detail > 1 || activeTool !== 'select') return;
                               setSelectedSeats(prev=>{
                                 const set = new Set(prev);
-                                if (!e.shiftKey) set.clear();
+                                if (!e.ctrlKey) set.clear();
                                 if (set.has(seat.id)) set.delete(seat.id); else set.add(seat.id);
                                 return set;
                               });


### PR DESCRIPTION
## Summary
- replace Shift with Ctrl for multi-select actions on benches and seats

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')
- `npm install` (fails: 403 Forbidden - GET https://registry.npmjs.org/html2canvas)


------
https://chatgpt.com/codex/tasks/task_e_68be9e2b4054832393fbce72b3bab910