### PR TITLE
Support separate PUBLIC_BASE_URL_API for ZCredit callbacks

### DIFF
--- a/.env.e
+++ b/.env.e
@@ -16,3 +16,4 @@ ZCREDIT_TERMINAL=1234567
 ZCREDIT_PASSWORD=YOUR_TERMINAL_PASSWORD
 ZCREDIT_KEY=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
 PUBLIC_BASE_URL=https://yourdomain.com
+PUBLIC_BASE_URL_API=https://api.yourdomain.com

--- a/README.md
+++ b/README.md
@@ -25,7 +25,10 @@ ZCREDIT_CREATE_SESSION_URL=https://pci.zcredit.co.il/WebCheckout/api/CreateSessi
 ZCREDIT_WEBCHECKOUT_KEY=<webcheckout key>
 ZCREDIT_KEY=<guid key>
 PUBLIC_BASE_URL=https://yourdomain.com
+PUBLIC_BASE_URL_API=https://api.yourdomain.com
 ```
+
+`PUBLIC_BASE_URL` is used for customer-facing redirects, while `PUBLIC_BASE_URL_API` (optional) builds server callback URLs. If `PUBLIC_BASE_URL_API` is not provided the server falls back to `PUBLIC_BASE_URL`.
 
 The server exposes two endpoints:
 

--- a/server/index.js
+++ b/server/index.js
@@ -38,6 +38,7 @@ const must = (name) => {
 
 const ZCREDIT_KEY = must('ZCREDIT_KEY');
 const PUBLIC_BASE_URL = must('PUBLIC_BASE_URL');
+const PUBLIC_BASE_URL_API = process.env.PUBLIC_BASE_URL_API || PUBLIC_BASE_URL;
 const SMTP_HOST = must('SMTP_HOST');
 const SMTP_PORT = must('SMTP_PORT');
 const SMTP_USER = must('SMTP_USER');
@@ -80,7 +81,7 @@ app.get('/health', (req, res) => res.json({ status: 'ok' }));
 registerAuthRoutes(app, { transporter, generatePassword, SMTP_USER });
 registerUserRoutes(app);
 registerStorageRoutes(app);
-registerZCreditRoutes(app, { transporter, generatePassword, PUBLIC_BASE_URL, ZCREDIT_KEY, SMTP_USER });
+registerZCreditRoutes(app, { transporter, generatePassword, PUBLIC_BASE_URL, PUBLIC_BASE_URL_API, ZCREDIT_KEY, SMTP_USER });
 registerContactRoutes(app, { transporter, SMTP_USER });
 registerCreditChargeRoutes(app);
 

--- a/server/routes/zcredit.js
+++ b/server/routes/zcredit.js
@@ -2,7 +2,7 @@ import axios from 'axios';
 import crypto from 'crypto';
 import { query } from '../db.js';
 
-export default function registerZCreditRoutes(app, { transporter, generatePassword, PUBLIC_BASE_URL, ZCREDIT_KEY, SMTP_USER }) {
+export default function registerZCreditRoutes(app, { transporter, generatePassword, PUBLIC_BASE_URL, PUBLIC_BASE_URL_API, ZCREDIT_KEY, SMTP_USER }) {
   app.post('/api/zcredit/create-checkout', async (req, res) => {
     try {
       const { amount, description, customerName, customerEmail, orderId, coupon, installments } = req.body || {};
@@ -20,11 +20,15 @@ export default function registerZCreditRoutes(app, { transporter, generatePasswo
       }
   
       const uniqueOrderId = orderId || `ORD-${Date.now()}`;
-  
+
+      // בסיסי כתובות ללא לוכסן סופי
+      const publicBase = (PUBLIC_BASE_URL || '').replace(/\/+$/, '');
+      const apiBase = (PUBLIC_BASE_URL_API || publicBase).replace(/\/+$/, '');
+
       // URLs לחזרה
-      const successUrl  = `${PUBLIC_BASE_URL}/#/thank-you?orderId=${encodeURIComponent(uniqueOrderId)}`;
-      const cancelUrl   = `${PUBLIC_BASE_URL}/#/payment-cancelled?orderId=${encodeURIComponent(uniqueOrderId)}`;
-      const callbackUrl = `${PUBLIC_BASE_URL_API}/api/zcredit/callback`;
+      const successUrl  = `${publicBase}/#/thank-you?orderId=${encodeURIComponent(uniqueOrderId)}`;
+      const cancelUrl   = `${publicBase}/#/payment-cancelled?orderId=${encodeURIComponent(uniqueOrderId)}`;
+      const callbackUrl = `${apiBase}/api/zcredit/callback`;
   
       // payload לפי ה־spec של WebCheckout (שמות/רישיות חשובים!)
       const payload = {


### PR DESCRIPTION
## Summary
- trim trailing slashes from base URLs and use `PUBLIC_BASE_URL_API` when building ZCredit callback URL
- document `PUBLIC_BASE_URL_API` in README and sample env file

## Testing
- `npm ci` (fails: 403 Forbidden - GET https://registry.npmjs.org/html2canvas)
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js`)


------
https://chatgpt.com/codex/tasks/task_e_68bed6f402f8832397e3d1ad28704023