### PR TITLE
Verify SMTP connection before sending contact emails

### DIFF
--- a/server/routes/contact.js
+++ b/server/routes/contact.js
@@ -7,6 +7,13 @@ export default function registerContactRoutes(app, { transporter, SMTP_USER }) {
 
     try {
       console.log(`Sending contact email from ${name} <${email}>`);
+      try {
+        await transporter.verify();
+      } catch (err) {
+        console.error('SMTP verify failed', err);
+        return res.status(503).json({ error: 'Email service unavailable' });
+      }
+
       const info = await transporter.sendMail({
         from: SMTP_USER,
         to: '0121718aaa@gmail.com',


### PR DESCRIPTION
## Summary
- ensure /api/contact checks SMTP connection with `transporter.verify` before sending mail

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden retrieving html2canvas)*

------
https://chatgpt.com/codex/tasks/task_e_68bee0976cc48323ad093421e9391da6