### PR TITLE
feat: handle contact form on server

### DIFF
--- a/.env.e
+++ b/.env.e
@@ -4,11 +4,12 @@ PORT=5001
 DATABASE_URL=postgres://seating_user:**********@seatflow.tech:5432/seating_db
 
 # mail server
-MAIL_HOST=smtp.mailserver.com
-MAIL_PORT=587
-MAIL_USERNAME=your-mail-username
-MAIL_PASSWORD=your-mail-password
-MAIL_FROM="ניהול מושבים חכם<no-reply@seatflow.tech>"
+SMTP_HOST=smtp.mailserver.com
+SMTP_PORT=587
+SMTP_USER=your-mail-username
+SMTP_PASS=your-mail-password
+SMTP_SECURE=false
+CONTACT_EMAIL=info@seatflow.online
 
 # ZCredit WebCheckout
 ZCREDIT_BASE_URL=https://pci.zcredit.co.il/zCreditWS/

--- a/README.md
+++ b/README.md
@@ -36,3 +36,16 @@ The server exposes two endpoints:
 - `POST /api/zcredit/callback` – receives the server-to-server notification from ZCredit after payment.
 
 Adjust endpoint URLs and payload fields according to your ZCredit documentation.
+
+### Contact form
+
+Provide SMTP credentials and a `CONTACT_EMAIL` environment variable so the `/api/contact` endpoint can forward submissions to your inbox:
+
+```
+SMTP_HOST=smtp.mailserver.com
+SMTP_PORT=587
+SMTP_USER=your-mail-username
+SMTP_PASS=your-mail-password
+SMTP_SECURE=false
+CONTACT_EMAIL=info@seatflow.online
+```

--- a/server/index.js
+++ b/server/index.js
@@ -44,6 +44,7 @@ const SMTP_PORT = must('SMTP_PORT');
 const SMTP_USER = must('SMTP_USER');
 const SMTP_PASS = must('SMTP_PASS');
 const SMTP_SECURE = must('SMTP_SECURE') === 'true';
+const CONTACT_EMAIL = must('CONTACT_EMAIL');
 
 const allowedOrigins = [
   'https://seatflow.tech',
@@ -82,7 +83,7 @@ registerAuthRoutes(app, { transporter, generatePassword, SMTP_USER });
 registerUserRoutes(app);
 registerStorageRoutes(app);
 registerZCreditRoutes(app, { transporter, generatePassword, PUBLIC_BASE_URL, PUBLIC_BASE_URL_API, ZCREDIT_KEY, SMTP_USER });
-registerContactRoutes(app, { transporter, SMTP_USER });
+registerContactRoutes(app, { transporter, SMTP_USER, CONTACT_EMAIL });
 registerCreditChargeRoutes(app);
 
 const PORT = Number(process.env.PORT || 4001);

--- a/server/routes/contact.js
+++ b/server/routes/contact.js
@@ -1,4 +1,4 @@
-export default function registerContactRoutes(app, { transporter, SMTP_USER }) {
+export default function registerContactRoutes(app, { transporter, SMTP_USER, CONTACT_EMAIL }) {
   app.post('/api/contact', async (req, res) => {
     const { name, email, subject, message } = req.body || {};
     if (!name || !email || !message) {
@@ -16,7 +16,7 @@ export default function registerContactRoutes(app, { transporter, SMTP_USER }) {
 
       const info = await transporter.sendMail({
         from: SMTP_USER,
-        to: '0121718aaa@gmail.com',
+        to: CONTACT_EMAIL,
         replyTo: email,
         subject: subject || `Contact form submission from ${name}`,
         text: `Name: ${name}\nEmail: ${email}\n\n${message}`

--- a/src/components/Contact/Contact.tsx
+++ b/src/components/Contact/Contact.tsx
@@ -20,6 +20,7 @@ import {
 import Align from '../common/Align';
 import { ContactForm } from '../../types';
 import Header from '../common/Header';
+import { API_BASE_URL } from '../../api';
 
 // Dimensions for the map modal
 const MAP_MODAL_WIDTH = 600;
@@ -70,7 +71,7 @@ const Contact: React.FC = () => {
 
     setIsSubmitting(true);
     try {
-      const res = await fetch('/api/contact', {
+      const res = await fetch(`${API_BASE_URL}/api/contact`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(formData)


### PR DESCRIPTION
## Summary
- forward contact form submissions from server using configurable CONTACT_EMAIL
- post contact messages to API base URL from client
- document SMTP and contact email environment variables

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm run build` *(fails: vite: not found)*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/html2canvas)*

------
https://chatgpt.com/codex/tasks/task_e_68bf1b3300e88323baad2d25c96e9acd