### PR TITLE
Add print-friendly styles for map view

### DIFF
--- a/src/components/Seats/MapView.tsx
+++ b/src/components/Seats/MapView.tsx
@@ -124,7 +124,7 @@ const MapView: React.FC = () => {
   }, [benches, mapBounds, baseSize, zoom, setMapOffset]);
 
   return (
-    <div className="min-h-screen w-full overflow-auto bg-gray-100">
+    <div className="min-h-screen w-full overflow-auto bg-gray-100 print:h-auto print:min-h-full print:overflow-visible">
       <div ref={containerRef} className="relative h-screen w-full">
         <div className="absolute top-4 right-4 z-10 flex flex-col items-center space-y-2">
           <MapZoomControls setZoom={setZoom} orientation="vertical" />

--- a/src/index.css
+++ b/src/index.css
@@ -95,7 +95,12 @@ body {
     transition: left 0.5s;
   }
 
-  .btn-hover:hover::before {
-    left: 100%;
+    .btn-hover:hover::before {
+      left: 100%;
+    }
   }
+
+@media print {
+  .min-h-screen, .h-screen { min-height: auto !important; height: auto !important; }
+  .overflow-auto { overflow: visible !important; }
 }


### PR DESCRIPTION
## Summary
- add print-specific overrides to ensure map containers expand fully and overflow is visible during printing
- apply matching Tailwind print classes to map view container

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js'; npm ci failed with 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68c1cf441ccc8323ae2e0a1045a34a30