### PR TITLE
Ensure boundary markers display above all seat map elements

### DIFF
--- a/src/components/Seats/MapView.tsx
+++ b/src/components/Seats/MapView.tsx
@@ -220,7 +220,7 @@ const MapView: React.FC = () => {
             ))}
 
             {/* Boundaries */}
-            <svg className="absolute inset-0 pointer-events-none">
+            <svg className="absolute inset-0 pointer-events-none z-50">
               {boundaries.map(b => (
                 <rect
                   key={b.id}

--- a/src/components/Seats/SeatsManagement.tsx
+++ b/src/components/Seats/SeatsManagement.tsx
@@ -1023,7 +1023,7 @@ function SeatsManagement(): JSX.Element {
               })}
 
               {/* Boundaries */}
-              <svg className="absolute inset-0 pointer-events-none">
+              <svg className="absolute inset-0 pointer-events-none z-50">
                 {boundaries.map(b => (
                   <rect
                     key={b.id}


### PR DESCRIPTION
## Summary
- Keep boundary markers on a high z-index layer so they are never obscured by benches or selection overlays

## Testing
- `npm test` *(fails: Missing script "test" )*
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm install` *(fails: 403 Forbidden when fetching html2canvas)*
- `npm run build` *(fails: vite not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c1d83e69e483239b67354b8c04bf71