### PR TITLE
Use PDF export for map view

### DIFF
--- a/src/components/Seats/MapView.tsx
+++ b/src/components/Seats/MapView.tsx
@@ -5,7 +5,8 @@ import { useAuth } from '../../context/AuthContext';
 import { Seat, Worshiper } from '../../types';
 import { API_BASE_URL } from '../../api';
 import MapZoomControls from './MapZoomControls';
-import { Printer, Target, Tags } from 'lucide-react';
+import { Printer, Target, Tags, FileDown } from 'lucide-react';
+import { exportMapToPDF } from '../../utils/pdfUtils';
 
 const MapView: React.FC = () => {
   const { id } = useParams<{ id?: string }>();
@@ -23,7 +24,8 @@ const MapView: React.FC = () => {
   } = useAppContext();
   const { user } = useAuth();
   const navigate = useNavigate();
-  const containerRef = useRef<HTMLDivElement>(null);
+  const wrapperRef = useRef<HTMLDivElement>(null);
+  const mapLayerRef = useRef<HTMLDivElement>(null);
   const [baseSize, setBaseSize] = useState({ width: 1200, height: 800 });
   const [zoom, setZoom] = useState(1);
   const mapId = id || currentMapId;
@@ -40,7 +42,7 @@ const MapView: React.FC = () => {
   }, []);
 
   useLayoutEffect(() => {
-    const el = containerRef.current;
+    const el = wrapperRef.current;
     if (!el) return;
     const update = () => setBaseSize({ width: el.clientWidth, height: el.clientHeight });
     update();
@@ -123,11 +125,27 @@ const MapView: React.FC = () => {
     });
   }, [benches, mapBounds, baseSize, zoom, setMapOffset]);
 
+  const handleExportOnePage = () =>
+    exportMapToPDF({
+      wrapperEl: wrapperRef.current!,
+      mapLayerEl: mapLayerRef.current!,
+      mode: 'onePage',
+      colorMode: 'color',
+    });
+
+  const handleExportA4 = () =>
+    exportMapToPDF({
+      wrapperEl: wrapperRef.current!,
+      mapLayerEl: mapLayerRef.current!,
+      mode: 'a4',
+      colorMode: 'color',
+    });
+
   return (
     <div className="min-h-screen w-full overflow-auto bg-gray-100 print:h-auto print:min-h-full print:w-auto print:min-w-full print:overflow-visible">
-      <div ref={containerRef} className="relative h-screen w-full print:h-auto print:w-auto print:min-w-full">
+      <div ref={wrapperRef} className="relative h-screen w-full print:h-auto print:w-auto print:min-w-full">
 
-        <div className="absolute top-4 right-4 z-10 flex flex-col items-center space-y-2">
+        <div className="absolute top-4 right-4 z-10 flex flex-col items-center space-y-2 pdf-hide">
           <MapZoomControls setZoom={setZoom} orientation="vertical" />
           <button
             onClick={centerMap}
@@ -137,9 +155,16 @@ const MapView: React.FC = () => {
             <Target className="h-4 w-4" />
           </button>
           <button
-            onClick={() => window.print()}
+            onClick={handleExportOnePage}
             className="p-2 rounded-lg bg-gray-100 text-gray-600 hover:bg-gray-200 transition-colors"
-            aria-label="הדפס מפה"
+            aria-label="ייצוא מפה (עמוד אחד)"
+          >
+            <FileDown className="h-4 w-4" />
+          </button>
+          <button
+            onClick={handleExportA4}
+            className="p-2 rounded-lg bg-gray-100 text-gray-600 hover:bg-gray-200 transition-colors"
+            aria-label="הדפס מפה A4"
           >
             <Printer className="h-4 w-4" />
           </button>
@@ -156,6 +181,7 @@ const MapView: React.FC = () => {
           style={{ width: baseSize.width + mapBounds.left + mapBounds.right, height: baseSize.height + mapBounds.top + mapBounds.bottom }}
         >
           <div
+            ref={mapLayerRef}
             className="absolute inset-0"
             style={{ transform: `translate(${mapOffset.x}px, ${mapOffset.y}px) scale(${zoom})`, transformOrigin: 'top left' }}
           >


### PR DESCRIPTION
## Summary
- use `exportMapToPDF` to generate printable map PDFs
- track wrapper and map layer DOM elements for PDF export
- hide UI controls from generated PDFs with `pdf-hide`
- add single-page and original-size A4 export options

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_68c1d85e26048323b433e8ef3822a77b