### PR TITLE
Use viewBox for boundary overlays

### DIFF
--- a/src/components/Seats/MapView.tsx
+++ b/src/components/Seats/MapView.tsx
@@ -29,6 +29,8 @@ const MapView: React.FC = () => {
   const [baseSize, setBaseSize] = useState({ width: 1200, height: 800 });
   const [zoom, setZoom] = useState(1);
   const mapId = id || currentMapId;
+  const wrapperWidth = baseSize.width + mapBounds.left + mapBounds.right;
+  const wrapperHeight = baseSize.height + mapBounds.top + mapBounds.bottom;
 
   useEffect(() => {
     const originalPadding = document.body.style.padding;
@@ -249,7 +251,12 @@ const MapView: React.FC = () => {
             ))}
 
             {/* Boundaries */}
-            <svg className="absolute inset-0 pointer-events-none z-50">
+            <svg
+              className="absolute inset-0 pointer-events-none z-50"
+              width="100%"
+              height="100%"
+              viewBox={`0 0 ${wrapperWidth} ${wrapperHeight}`}
+            >
               {boundaries.map(b => (
                 <rect
                   key={b.id}

--- a/src/components/Seats/SeatsManagement.tsx
+++ b/src/components/Seats/SeatsManagement.tsx
@@ -105,6 +105,8 @@ function SeatsManagement(): JSX.Element {
   // Refs
   const wrapperRef = useRef<HTMLDivElement>(null);
   const mapLayerRef = useRef<HTMLDivElement>(null);
+  const wrapperWidth = wrapperRef.current?.clientWidth ?? 0;
+  const wrapperHeight = wrapperRef.current?.clientHeight ?? 0;
 
   // Colors
   const benchColors = ['#3B82F6','#10B981','#F59E0B','#EF4444','#8B5CF6','#06B6D4','#1F2937','#6366F1','#14B8A6','#D946EF','#F97316','#84CC16','#E879F9','#22D3EE','#F43F5E','#A855F7'];
@@ -1023,7 +1025,12 @@ function SeatsManagement(): JSX.Element {
               })}
 
               {/* Boundaries */}
-              <svg className="absolute inset-0 pointer-events-none z-50">
+              <svg
+                className="absolute inset-0 pointer-events-none z-50"
+                width="100%"
+                height="100%"
+                viewBox={`0 0 ${wrapperWidth} ${wrapperHeight}`}
+              >
                 {boundaries.map(b => (
                   <rect
                     key={b.id}


### PR DESCRIPTION
## Summary
- size boundary overlays with viewBox in SeatsManagement and MapView
- compute wrapper dimensions to keep boundary coordinates within SVG viewBox

## Testing
- ⚠️ `npm install` (403 Forbidden fetching html2canvas)
- ⚠️ `npm run lint` (missing @eslint/js due to failed install)
- ⚠️ `npm run build` (vite not found)
- ⚠️ `npm run dev` (vite not found)


------
https://chatgpt.com/codex/tasks/task_e_68c1ddf07720832381982b00de18e5eb