### PR TITLE
Scale map export to half size

### DIFF
--- a/src/utils/pdfUtils.ts
+++ b/src/utils/pdfUtils.ts
@@ -123,6 +123,16 @@ async function renderBBoxToCanvas(el: HTMLDivElement, bbox: {x:number;y:number;w
   return canvas;
 }
 
+// ---------- הקטנת קנבס לגודל מסוים ----------
+function scaleCanvas(canvas: HTMLCanvasElement, factor: number) {
+  const scaled = document.createElement('canvas');
+  scaled.width = Math.round(canvas.width * factor);
+  scaled.height = Math.round(canvas.height * factor);
+  const ctx = scaled.getContext('2d')!;
+  ctx.drawImage(canvas, 0, 0, scaled.width, scaled.height);
+  return scaled;
+}
+
 // ---------- עוזרים להמרות יחידות ----------
 const mmToPt = (mm: number) => (mm * 72) / 25.4; // jsPDF עובד ב-pt (72pt = 1in = 25.4mm)
 const pxToPt = (px: number, pxPerPt = 96 / 72) => px / pxPerPt; // הנחה של 96dpi בדפדפן
@@ -145,6 +155,7 @@ export async function exportMapToPDF(opts: ExportOpts) {
 
   // 2) מצלמים את כל המפה לקנבס
   let canvas = await renderBBoxToCanvas(mapLayerEl, bbox);
+  canvas = scaleCanvas(canvas, 0.5);
 
   // 3) עיבוד צבע אופציונלי
   if (colorMode === 'bw' && bwHard) {


### PR DESCRIPTION
## Summary
- shrink exported map images by adding a scaleCanvas helper
- ensure exportMapToPDF scales the captured map canvas to 50% before PDF generation

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Cannot find package '@eslint/js')*
- `npm install` *(fails: 403 Forbidden - GET https://registry.npmjs.org/html2canvas)*

------
https://chatgpt.com/codex/tasks/task_e_68c1e19c2f288323a77b813e451f4c09