### PR TITLE
feat: admin role management and ZCredit logs

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -12,6 +12,7 @@ import registerStorageRoutes from './routes/storage.js';
 import registerZCreditRoutes from './routes/zcredit.js';
 import registerContactRoutes from './routes/contact.js';
 import registerCreditChargeRoutes from './routes/creditCharges.js';
+import registerZcreditCallbackRoutes from './routes/zcreditCallbacks.js';
 
 const app = express();
 
@@ -92,6 +93,7 @@ registerZCreditRoutes(app, {
 });
 registerContactRoutes(app, { transporter, SMTP_USER, CONTACT_EMAIL });
 registerCreditChargeRoutes(app);
+registerZcreditCallbackRoutes(app);
 
 const PORT = Number(process.env.PORT || 4001);
 app.listen(PORT, () => console.log(`Server running on port ${PORT}`));

--- a/server/routes/users.js
+++ b/server/routes/users.js
@@ -18,6 +18,21 @@ export default function registerUserRoutes(app) {
     }
   });
 
+  app.put('/api/users/:email/role', async (req, res) => {
+    const { email } = req.params;
+    const { role } = req.body || {};
+    if (!['demo', 'pro', 'manager'].includes(role)) {
+      return res.status(400).json({ error: 'Invalid role' });
+    }
+    try {
+      await query('UPDATE users SET role=$1 WHERE email=$2', [role, email]);
+      res.sendStatus(204);
+    } catch (err) {
+      console.error('update role error:', err);
+      res.status(500).json({ error: 'DB error' });
+    }
+  });
+
   app.get('/api/users/:email', async (req, res) => {
     try {
       const { rows } = await query(

--- a/server/routes/zcreditCallbacks.js
+++ b/server/routes/zcreditCallbacks.js
@@ -1,0 +1,15 @@
+import { query } from '../db.js';
+
+export default function registerZcreditCallbackRoutes(app) {
+  app.get('/api/zcredit-callbacks', async (req, res) => {
+    try {
+      const { rows } = await query(
+        `SELECT id, payload, received_at AS "receivedAt" FROM zcredit_callbacks ORDER BY id DESC`
+      );
+      res.json(rows);
+    } catch (err) {
+      console.error('list zcredit callbacks error:', err);
+      res.status(500).json({ error: 'DB error' });
+    }
+  });
+}

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -20,6 +20,8 @@ import Home from './components/Home/Home';
 import UserManagement from './components/Admin/UserManagement';
 import DefaultMapView from './components/Admin/DefaultMapView';
 import CreditCharges from './components/Admin/CreditCharges';
+import RoleManagement from './components/Admin/RoleManagement';
+import ZcreditCallbacks from './components/Admin/ZcreditCallbacks';
 import RequireManager from './components/Auth/RequireManager';
 import CouponPopup from './components/common/CouponPopup';
 
@@ -74,8 +76,10 @@ function App() {
             <Route path="seats-manage" element={<SeatsManagement />} />
             <Route path="map-guide" element={<MapManagementGuide />} />
             <Route path="admin-users" element={<RequireManager><UserManagement /></RequireManager>} />
+            <Route path="admin-roles" element={<RequireManager><RoleManagement /></RequireManager>} />
             <Route path="default-map" element={<RequireManager><DefaultMapView /></RequireManager>} />
             <Route path="credit-charges" element={<RequireManager><CreditCharges /></RequireManager>} />
+            <Route path="zcredit-callbacks" element={<RequireManager><ZcreditCallbacks /></RequireManager>} />
             <Route path="contact" element={<Contact />} />
             <Route path="pricing" element={<Pricing />} />
           </Route>

--- a/src/components/Admin/RoleManagement.tsx
+++ b/src/components/Admin/RoleManagement.tsx
@@ -1,0 +1,55 @@
+import React, { useEffect, useState } from 'react';
+import { API_BASE_URL } from '../../api';
+
+interface User {
+  email: string;
+  role: string;
+}
+
+const RoleManagement: React.FC = () => {
+  const [users, setUsers] = useState<User[]>([]);
+
+  useEffect(() => {
+    fetch(`${API_BASE_URL}/api/users`)
+      .then(res => res.json())
+      .then(setUsers)
+      .catch(err => console.error('load users error', err));
+  }, []);
+
+  const updateRole = async (email: string, role: string) => {
+    try {
+      await fetch(`${API_BASE_URL}/api/users/${email}/role`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ role }),
+      });
+      setUsers(prev => prev.map(u => (u.email === email ? { ...u, role } : u)));
+    } catch (err) {
+      console.error('update role error', err);
+    }
+  };
+
+  return (
+    <div>
+      <h2 className="text-2xl font-bold mb-4">ניהול תפקידי משתמשים</h2>
+      <div className="grid gap-4">
+        {users.map(user => (
+          <div key={user.email} className="border rounded p-4 shadow">
+            <div className="font-bold mb-2">{user.email}</div>
+            <select
+              value={user.role}
+              onChange={e => updateRole(user.email, e.target.value)}
+              className="border p-1 rounded"
+            >
+              <option value="demo">demo</option>
+              <option value="pro">pro</option>
+              <option value="manager">manager</option>
+            </select>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default RoleManagement;

--- a/src/components/Admin/ZcreditCallbacks.tsx
+++ b/src/components/Admin/ZcreditCallbacks.tsx
@@ -1,0 +1,39 @@
+import React, { useEffect, useState } from 'react';
+import { API_BASE_URL } from '../../api';
+
+interface Callback {
+  id: number;
+  payload: unknown;
+  receivedAt: string;
+}
+
+const ZcreditCallbacks: React.FC = () => {
+  const [callbacks, setCallbacks] = useState<Callback[]>([]);
+
+  useEffect(() => {
+    fetch(`${API_BASE_URL}/api/zcredit-callbacks`)
+      .then(res => res.json())
+      .then(setCallbacks)
+      .catch(err => console.error('load zcredit callbacks error', err));
+  }, []);
+
+  return (
+    <div>
+      <h2 className="text-2xl font-bold mb-4">ZCredit Callbacks</h2>
+      <div className="grid gap-4">
+        {callbacks.map(cb => (
+          <div key={cb.id} className="border rounded p-4 text-sm break-words">
+            <div className="text-gray-600 mb-2">
+              {new Date(cb.receivedAt).toLocaleString('he-IL')}
+            </div>
+            <pre className="whitespace-pre-wrap">
+              {JSON.stringify(cb.payload, null, 2)}
+            </pre>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+};
+
+export default ZcreditCallbacks;

--- a/src/components/Layout/Navbar.tsx
+++ b/src/components/Layout/Navbar.tsx
@@ -11,7 +11,9 @@ import {
   X,
   UserMinus,
   Map,
-  Receipt
+  Receipt,
+  Shield,
+  Database
 } from 'lucide-react';
 import { useAuth } from '../../context/AuthContext';
 import Logo from '../common/Logo';
@@ -32,8 +34,10 @@ const Navbar: React.FC = () => {
     { path: '/app/seats-manage', label: 'ניהול מקומות', icon: Settings },
     { path: '/app/map-guide', label: 'מדריך מפה', icon: HelpCircle },
     { path: '/app/admin-users', label: 'מחיקת משתמשים', icon: UserMinus, admin: true },
+    { path: '/app/admin-roles', label: 'תפקידי משתמשים', icon: Shield, admin: true },
     { path: '/app/default-map', label: 'מפת ברירת מחדל', icon: Map, admin: true },
     { path: '/app/credit-charges', label: 'חיובים', icon: Receipt, admin: true },
+    { path: '/app/zcredit-callbacks', label: 'ZCredit פרטי חיוב', icon: Database, admin: true },
     { path: '/app/contact', label: 'צור קשר', icon: Mail },
     { path: '/app/pricing', label: 'מחירון', icon: CreditCard },
   ];


### PR DESCRIPTION
## Summary
- manage user roles in admin panel
- display stored ZCredit callback payloads

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (fails: Cannot find package '@eslint/js')

------
https://chatgpt.com/codex/tasks/task_e_68c29f4b170883238fe36c1e9e9b1972